### PR TITLE
Vector Control placeholders in MBITES landscape

### DIFF
--- a/MASH-MICRO/R/Site-Class.R
+++ b/MASH-MICRO/R/Site-Class.R
@@ -307,5 +307,7 @@ SugarSite <- R6::R6Class(classname = "SugarSite",
                    # Pointers
                    LandscapePointer = NULL
 
+                   # Vector Control
+                   attractiveSugarBait=NULL
                  )
 )

--- a/MASH-MICRO/R/Site-Class.R
+++ b/MASH-MICRO/R/Site-Class.R
@@ -239,8 +239,11 @@ MatingSite <- R6::R6Class(classname = "MatingSite",
                    MatingQ = NULL,           # host risk queue
 
                    # Pointers
-                   LandscapePointer = NULL
+                   LandscapePointer = NULL,
 
+                   # Vector Control
+                   aerialSpray=NULL,
+                   swarmSpray=NULL
                  )
 )
 
@@ -305,7 +308,7 @@ SugarSite <- R6::R6Class(classname = "SugarSite",
                    haz = numeric(1),
 
                    # Pointers
-                   LandscapePointer = NULL
+                   LandscapePointer = NULL,
 
                    # Vector Control
                    attractiveSugarBait=NULL

--- a/MASH-MICRO/R/Site-Class.R
+++ b/MASH-MICRO/R/Site-Class.R
@@ -82,8 +82,13 @@ FeedingSite <- R6::R6Class(classname = "FeedingSite",
                    RiskQ = NULL,           # host risk queue
 
                    # Pointers
-                   LandscapePointer = NULL
+                   LandscapePointer = NULL,
 
+                   # Vector Control
+                   odorBaitedTrap=NULL,
+                   eaveTube=NULL,
+                   homeImprovement=NULL,
+                   indoorResidualSpray=NULL
                  )
 )
 
@@ -173,6 +178,12 @@ AquaticSite <- R6::R6Class(classname = "AquaticSite",
                    # Pointers
                    LandscapePointer = NULL
 
+                   # Vector Control
+                   aerialSpray=NULL,
+                   areaRepellent=NULL,
+                   biologicalControl=NULL,
+                   larviciding=NULL,
+                   ovitrap=NULL
                  )
 )
 
@@ -244,7 +255,7 @@ MatingSite <- R6::R6Class(classname = "MatingSite",
                    # Vector Control
                    aerialSpray=NULL,
                    swarmSpray=NULL,
-                   areaRepellant=NULL
+                   areaRepellent=NULL
                  )
 )
 
@@ -313,6 +324,7 @@ SugarSite <- R6::R6Class(classname = "SugarSite",
 
                    # Vector Control
                    attractiveSugarBait=NULL,
-                   aerialSpray=NULL
+                   aerialSpray=NULL,
+                   areaRepellent=NULL
                  )
 )

--- a/MASH-MICRO/R/Site-Class.R
+++ b/MASH-MICRO/R/Site-Class.R
@@ -243,7 +243,8 @@ MatingSite <- R6::R6Class(classname = "MatingSite",
 
                    # Vector Control
                    aerialSpray=NULL,
-                   swarmSpray=NULL
+                   swarmSpray=NULL,
+                   areaRepellant=NULL
                  )
 )
 
@@ -311,6 +312,7 @@ SugarSite <- R6::R6Class(classname = "SugarSite",
                    LandscapePointer = NULL,
 
                    # Vector Control
-                   attractiveSugarBait=NULL
+                   attractiveSugarBait=NULL,
+                   aerialSpray=NULL
                  )
 )

--- a/MASH-dev/HectorSanchez/AssortedScripts/TEST-MICRO.R
+++ b/MASH-dev/HectorSanchez/AssortedScripts/TEST-MICRO.R
@@ -22,9 +22,14 @@ library(MASHmicro)
 # make a tile
 if(system("whoami",intern=TRUE)=="slwu89"){
   DIR="/Users/slwu89/Desktop/MASHOUT/"
+}else if(system("whoami",intern=TRUE)=="sanchez.hmsc"){
+  DIR="/Users/sanchez.hmsc/Desktop/MASHOUT/"
+  sourceEntireFolder("/Users/sanchez.hmsc/Documents/Github/MASH-Main/MASH-MICRO/R/")
 }else if(system("whoami",intern=TRUE)=="chipdelmal"){
   DIR="/Users/chipdelmal/Desktop/MASHOUT/"
 }
+
+
 
 # setup
 Humans.MICRO.Setup()
@@ -68,4 +73,4 @@ mosquito_par = list(
 MicroTile = Tile$new(Landscape_PAR = landscape_par,HumanPop_PAR = human_par,MosquitoPop_PAR = mosquito_par,directory = DIR)
 MicroTile$get_HumanPop()$init_ActivitySpace()
 MicroTile$get_HumanPop()$init_PfSI(PfPR = 0.95)
-MicroTile$simMICRO_oneRun(tMax = 365,verbose = TRUE,trackPop = TRUE)
+MicroTile$simMICRO_oneRun(tMax = 50,verbose = TRUE,trackPop = TRUE)

--- a/MASH-dev/HectorSanchez/AssortedScripts/TEST-MICRO.R
+++ b/MASH-dev/HectorSanchez/AssortedScripts/TEST-MICRO.R
@@ -27,6 +27,7 @@ if(system("whoami",intern=TRUE)=="slwu89"){
   sourceEntireFolder("/Users/sanchez.hmsc/Documents/Github/MASH-Main/MASH-MICRO/R/")
 }else if(system("whoami",intern=TRUE)=="chipdelmal"){
   DIR="/Users/chipdelmal/Desktop/MASHOUT/"
+  sourceEntireFolder("/Users/sanchez.hmsc/Documents/Github/MASH-Main/MASH-MICRO/R/")
 }
 
 

--- a/MASH-dev/HectorSanchez/AssortedScripts/sourceEntireFolder.R
+++ b/MASH-dev/HectorSanchez/AssortedScripts/sourceEntireFolder.R
@@ -1,0 +1,14 @@
+library(R.utils)
+sourceEntireFolder <- function(folderName, verbose=FALSE, showWarnings=TRUE) {
+  files=list.files(folderName, full.names=TRUE)
+  # Grab only R files
+  files=files[ grepl("\\.[rR]$", files) ]
+  if (!length(files) && showWarnings){warning("No R files in ", folderName)}
+  for (f in files) {
+    if (verbose)
+      cat("sourcing: ", f, "\n")
+    ## TODO:  add caught whether error or not and return that
+    try(source(f, local=FALSE, echo=FALSE), silent=!verbose)
+  }
+  return(invisible(NULL))
+}


### PR DESCRIPTION
I'm adding vector control interventions **placeholder** attributes to the **landscape** objects (FeedingSite, SugarSite, MatingSite, AquaticSite). These attributes will hold the **VC objects** in place once they are ported into the package. These attributes are, for now, initialized to **NULL**, but this will change as I start to move my previous versions of these interventions.

_Changes have been sourced and code is working as expected (nothing should really change from previous versions)._ 

Other minor changes were made in my dev folder. These changes are for my own workflow and don't have any secondary effects on anything else. A function that might be of interest to everyone else is: **sourceEntireFolder**; which takes a directory as a parameter and sources every **R** file within it.