### PR TITLE
Vector control: Adding effects on Male Mosquitoes

### DIFF
--- a/MASH-MICRO/R/MBITES-Complex-Bouts.R
+++ b/MASH-MICRO/R/MBITES-Complex-Bouts.R
@@ -410,6 +410,7 @@ mbites_boutM <- function(){
       self$chooseMate()
       private$stateNew = "F"
     }
+    #### SwarmSpray #############################################################################################
     swarmSpray=private$LandscapePointer$get_MatingSites(private$locNow)$get_swarmSpray()
     if(is.null(swarmSpray)==FALSE){
         private$stateNew = swarmSpray$mosquitoKillEncounter(private$stateNew,interventionType="SwarmSpray")

--- a/MASH-MICRO/R/MBITES-Male-Bouts.R
+++ b/MASH-MICRO/R/MBITES-Male-Bouts.R
@@ -186,7 +186,12 @@ mbitesMale_boutS <- function(){
     }
     private$stateNew = "R"
   }
-
+  #### ATSB ################################################################################################
+  atsb=private$LandscapePointer$get_SugarSites(private$locNow)$get_attractiveSugarBait()
+  if(is.null(atsb)==FALSE){
+      private$stateNew = atsb$mosquitoKillEncounter(private$stateNew,interventionType="ATSB")
+      private$lspot = atsb$mosquitoRepelEncounter(private$lspot,interventionType="ATSB")
+  }
 }
 
 

--- a/MASH-MICRO/R/MBITES-Male-Bouts.R
+++ b/MASH-MICRO/R/MBITES-Male-Bouts.R
@@ -165,7 +165,12 @@ mbitesMale_boutM <- function(){
     private$LandscapePointer$get_MatingSites(private$locNow)$get_MatingQ()$add_male2Q(private$id,private$mateFitness,private$genotype)
     private$stateNew = "R"
   }
-
+  #### SwarmSpray #############################################################################################
+  swarmSpray=private$LandscapePointer$get_MatingSites(private$locNow)$get_swarmSpray()
+  if(is.null(swarmSpray)==FALSE){
+      private$stateNew = swarmSpray$mosquitoKillEncounter(private$stateNew,interventionType="SwarmSpray")
+      private$lspot = swarmSpray$mosquitoRepelEncounter(private$lspot,interventionType="SwarmSpray")
+  }
 }
 
 

--- a/MASH-dev/HectorSanchez/AssortedScripts/main.R
+++ b/MASH-dev/HectorSanchez/AssortedScripts/main.R
@@ -81,7 +81,7 @@ MicroTile$get_HumanPop()$init_PfSI(PfPR = 0.95)
 ### Sugar ######################################################
 sugarSitesNumber=MicroTile$get_Landscape()$get_SugarSitesN()
 for(i in 1:sugarSitesNumber){
-  atsbTest=ATSB$new(id=i,killProbability=1,repelProbability=0)
+  atsbTest=ATSB$new(id=i,killProbability=0,repelProbability=0)
   MicroTile$get_Landscape()$get_SugarSites(i)$set_attractiveSugarBait(atsbTest)
 }
 ### Aquatic ####################################################

--- a/MASH-dev/HectorSanchez/AssortedScripts/main.R
+++ b/MASH-dev/HectorSanchez/AssortedScripts/main.R
@@ -81,7 +81,7 @@ MicroTile$get_HumanPop()$init_PfSI(PfPR = 0.95)
 ### Sugar ######################################################
 sugarSitesNumber=MicroTile$get_Landscape()$get_SugarSitesN()
 for(i in 1:sugarSitesNumber){
-  atsbTest=ATSB$new(id=i,killProbability=0,repelProbability=0)
+  atsbTest=ATSB$new(id=i,killProbability=1,repelProbability=0)
   MicroTile$get_Landscape()$get_SugarSites(i)$set_attractiveSugarBait(atsbTest)
 }
 ### Aquatic ####################################################
@@ -103,7 +103,7 @@ for(i in 1:matingSitesNumber){
   MicroTile$get_Landscape()$get_MatingSites(i)$set_swarmSpray(swarmSprayTest)
 }
 ###### Run #############################################################################
-MicroTile$simMICRO_oneRun(tMax = 1000,verbose = TRUE,trackPop = TRUE)
+MicroTile$simMICRO_oneRun(tMax = 750,verbose = TRUE,trackPop = TRUE)
 
 ########################################################################################
 ###### TESTS ###########################################################################

--- a/MASH-dev/HectorSanchez/AssortedScripts/main.R
+++ b/MASH-dev/HectorSanchez/AssortedScripts/main.R
@@ -103,7 +103,7 @@ for(i in 1:matingSitesNumber){
   MicroTile$get_Landscape()$get_MatingSites(i)$set_swarmSpray(swarmSprayTest)
 }
 ###### Run #############################################################################
-MicroTile$simMICRO_oneRun(tMax = 20,verbose = TRUE,trackPop = TRUE)
+MicroTile$simMICRO_oneRun(tMax = 1000,verbose = TRUE,trackPop = TRUE)
 
 ########################################################################################
 ###### TESTS ###########################################################################

--- a/MASH-dev/HectorSanchez/VectorControl/PopCountsDebugger.nb
+++ b/MASH-dev/HectorSanchez/VectorControl/PopCountsDebugger.nb
@@ -10,10 +10,10 @@
 NotebookFileLineBreakTest
 NotebookFileLineBreakTest
 NotebookDataPosition[       158,          7]
-NotebookDataLength[     87789,       1697]
-NotebookOptionsPosition[     87333,       1678]
-NotebookOutlinePosition[     87688,       1694]
-CellTagsIndexPosition[     87645,       1691]
+NotebookDataLength[     82223,       1605]
+NotebookOptionsPosition[     81631,       1583]
+NotebookOutlinePosition[     82017,       1600]
+CellTagsIndexPosition[     81974,       1597]
 WindowFrame->Normal*)
 
 (* Beginning of Notebook Content *)
@@ -26,6 +26,9 @@ Cell[BoxData[
    RowBox[{"Import", " ", "and", " ", "Setup", " ", "Data"}], "*)"}], 
   "\[IndentingNewLine]", 
   RowBox[{
+   RowBox[{
+    RowBox[{"scenarioName", "=", "\"\<ATSBRepel\>\""}], ";"}], 
+   "\[IndentingNewLine]", 
    RowBox[{
     RowBox[{"folder", "=", 
      RowBox[{
@@ -77,7 +80,7 @@ Cell[BoxData[
        RowBox[{"{", 
         RowBox[{"mRaw", ",", "fRaw"}], "}"}]}]}]}], ";"}], 
    "\[IndentingNewLine]", 
-   RowBox[{"(*", "*)"}], "\[IndentingNewLine]", 
+   RowBox[{"(*", "Plots", "*)"}], "\[IndentingNewLine]", 
    RowBox[{
     RowBox[{"plots", "=", 
      RowBox[{
@@ -90,7 +93,7 @@ Cell[BoxData[
          "\[IndentingNewLine]", 
          RowBox[{"PlotRange", "\[Rule]", 
           RowBox[{"{", 
-           RowBox[{"0", ",", "All"}], "}"}]}], ",", "\[IndentingNewLine]", 
+           RowBox[{"0", ",", "50"}], "}"}]}], ",", "\[IndentingNewLine]", 
          RowBox[{"Frame", "\[Rule]", "True"}], ",", "\[IndentingNewLine]", 
          RowBox[{"FrameStyle", "\[Rule]", 
           RowBox[{"Directive", "[", 
@@ -109,271 +112,250 @@ Cell[BoxData[
        RowBox[{"{", 
         RowBox[{"data", ",", "head"}], "}"}], "]"}]}]}], ";"}], 
    "\[IndentingNewLine]", 
-   RowBox[{"Grid", "[", 
-    RowBox[{"{", 
-     RowBox[{"{", "}"}], "}"}], "]"}]}]}]], "Input",
- CellChangeTimes->{{3.721571945747401*^9, 3.7215719990110617`*^9}, {
-  3.72157204332439*^9, 3.721572106483636*^9}, {3.7215723999086027`*^9, 
-  3.7215724005084047`*^9}, {3.721572449629941*^9, 3.721572503515877*^9}, {
-  3.7215726378940973`*^9, 3.721572666649776*^9}, {3.721572712938615*^9, 
-  3.721572719485774*^9}, {3.721572760952183*^9, 3.721572790830947*^9}, {
-  3.721572852454445*^9, 3.721572917186318*^9}, {3.7215729473160887`*^9, 
-  3.7215729921324244`*^9}, {3.7215730785823708`*^9, 3.7215731056223783`*^9}, {
-  3.721573140145677*^9, 3.721573238165457*^9}, {3.721573326650441*^9, 
-  3.7215733506455727`*^9}, {3.721573390115328*^9, 3.7215734363921824`*^9}, {
-  3.7215734786963253`*^9, 3.7215735048958263`*^9}, {3.721573638388783*^9, 
-  3.721573657756658*^9}, {3.721573728540988*^9, 3.721573737865568*^9}, {
-  3.721573864682006*^9, 3.721573871059524*^9}, {3.721573909676648*^9, 
-  3.7215739535510683`*^9}},ExpressionUUID->"6e6e83fe-a091-422f-89b0-\
-b762b3bb1c02"],
+   RowBox[{"grid", "=", 
+    RowBox[{"Grid", "[", 
+     RowBox[{
+      RowBox[{"{", 
+       RowBox[{
+        RowBox[{
+         RowBox[{
+          RowBox[{"Rotate", "[", 
+           RowBox[{
+            RowBox[{"Style", "[", 
+             RowBox[{"#", ",", "30"}], "]"}], ",", 
+            RowBox[{"90", "Degree"}]}], "]"}], "&"}], "/@", 
+         RowBox[{"{", 
+          RowBox[{"\"\<Male\>\"", ",", "\"\<Female\>\""}], "}"}]}], ",", 
+        "plots"}], "}"}], "//", "Transpose"}], "]"}]}], "\[IndentingNewLine]", 
+   RowBox[{"(*", "Export", "*)"}], "\[IndentingNewLine]", 
+   RowBox[{"Export", "[", 
+    RowBox[{
+     RowBox[{
+      RowBox[{"NotebookDirectory", "[", "]"}], "<>", "\"\<Debug/\>\"", "<>", 
+      "scenarioName", "<>", "\"\<.png\>\""}], ",", "grid", ",", 
+     RowBox[{"ImageResolution", "\[Rule]", "500"}]}], "]"}]}]}]], "Input",
+ CellChangeTimes->CompressedData["
+1:eJwdz00ow3EcBvB/Qq2koZXWLC+1rdXyMm2KSM1aozbyOqVMmywxDsuWA5KN
+jZSitIatNRMlRUtTmmFpao3ITtuJTSGHOciy53f49rk8T0/fCvVklyaHoih2
+9uBZSnzfc/7e6lDFH+DosO4FfhsVCSgt+cvrzRqT0POhiVdfAOkLX8Vw2u6v
+gj933VxYSWMLoMH6SZTNsIWQvRUTwcjKWjPsTLulUFumk8NoU64ShpxRFVxK
+CYfgiHdRDcfbryegLvJohJb9x1kYPL6ahwGbzQw7ZE82aD9grcOkPrwLraIG
+F7xRFB1C/0njEcxEGRdw5zVBZHpOA1DlrA2R/xKuKMm5597IfljI6EN/Q0yM
+Uz4OLLcs8+Ci5kEAk6tTNdC0rWyCZ3stEli9ud8NCy59/TAj/9XC4DBnDGoZ
+bZOQr2TqocTDNUAHZSam+R91/VndgzQhfJ4p9MKTWzmx1MapHsjKah0i/gO1
+MvsI
+  "],ExpressionUUID->"6e6e83fe-a091-422f-89b0-b762b3bb1c02"],
 
 Cell[BoxData[
- RowBox[{"{", 
-  RowBox[{
-   TemplateBox[{GraphicsBox[{{}, {{{}, {}, {
-          Hue[0.67, 0.6, 0.6], 
-          Directive[
-           PointSize[0.005555555555555556], 
-           AbsoluteThickness[1.6], 
-           RGBColor[0.293416, 0.0574044, 0.529412]], 
-          LineBox[CompressedData["
-1:eJxdmjmw81YZhjXQuFRB4YJCeBjmDsMwZjdrFFZDIJhAEocliGyYJYkggRgI
-IJYfHFaXt1Tp0qVLlS5dulSHS5UuGcbf8zPnuc2Z577feo4k6xz7Xc+9+sSL
-b8uy7D9vz7L/jbe/4ZHb+JEy/hHjNMZRjO+NMRe/I8b3xDiOcRLjO8WF2OO7
-FZ+4dxptR9z3SX+//k9fxPmA8n9QdX9I+odVF/NGvo/K/2Pyn8XIPH1c9p9Q
-fZ8Uf0r5Px0jfX5G8R9RfWVaTwMT79EYY16bR1P77LPyh5mHz6X1NOLs84ov
-zr4QY6xXA+P/xRhjHRuY+r+k+DDrNld94uzLMcZ10cCTGL+i/DDr81jKzWOp
-ffZV1QdzfX4t5Qbmunxc9T8u/euqX5wtUvtS3MCRv4Pp7xtp/hKehD8c8TrZ
-Z0+k8UqYeuGYnw6mv2+m9ZVwXN8NjD8c9WXfSrmEWU84rpcO5vp6UvmfTPUG
-jv46mPqfSvXyqVRv4JivTvbZ06l9+XSqN3A8tzpxtlR+mOsRjvnoYOp/Jo1X
-PpPaN+JOnH07xljvEia/uIN5rn4nRq4/OOpppHcw99d30/glzPxJ76Rn31N+
-mP5h7h/ZZ8+m9iXM9Qtz/8Bcf99P45cw8wfjD+NfpfkKmHrgiFfBzI+4lX8H
-x/r2MP3/IK2ngFkPOOJVsm/g6L+Fo59Oeg+zfs+legGT/7nUvpJ9I72Fo74O
-jnp6cfa88j+f6iVMfumN9FZ6B08iv/JlL6T1Fi+k9iXM+osbONanld7B9A+T
-/8XUvoC5n+Cor4Kjvgamf+md9F569lKM8b5YvJTqpbiCuf7FLRzvwZ38e3H2
-w5QLOPotxZW4gWO+WpjPGzjmt4e5/lZpvQUc74uluJJ9A8f7agvHfHby78XZ
-j1L/Ap5EfjjyVXD4N/JvZd/BXH+Kn/04xtjHFHDUX0qv4MjXwFFPK+7k34uz
-n8QY+6pCXML0L72B6R+O+J3se3H20xhjn1fAka+UXokbOPaNrfRO3Iuzl9N8
-xcupXsJRbyW9kd4+1G9/nex72WevxMj6v5LqpfQKJr+4hWM+Oum9OHs15UJc
-iis44jfiVtyJe3FWE//2l9epXoinsi/Fi4cc9Ypr2TeKv5XeivfiTnwS9+JB
-nP0s5VxciKfiUrwQV+IaZv3EW9m30vfiTvYncS8e5J/9PNVzcQGz/uJSvJB/
-9ZBvYy37RryVfQvH/biXfSc+yb+XPihe9lpqn7+W2hfiqbiEI95C8So4nh81
-zOen9C3M54ni7ZWvk/9J8Xvpg/yz11POX0/tC/FU9qX0hfQKjs+nGqZ/2W+l
-t3DMx175OvFJ/r14gDkf/EXqn8O8j8CRfyou4Yi/gOkfjny1/BvxVvat9D08
-uY2d6j3Jv1d9g+yzX6acw+wHpU9h3o9g+pdeSa/FjfJt5d8q/156B8f78Enx
-ejjmbxBnb6TxcnhyG4s3Uvup7Es48i3g2N9UcNRXy78Rb8Wt4u9VXwfH+/5J
-+XvVPyh+tk45h2M/UcCRbyr7EqZ/2Veyr6U30rdwzFcLx/nBXvad6j2Jezjm
-ZxBnv0rryWH2w3Dsn6bSSzjiLcQVHOtRK18DR39bOM5rWsXby76D6V96r3iD
-6sl+HWOsXw6zH4cj/xRmfy77Bcx+FaZ/2TeKv4XjvLVVvr24g+P84QTH9yy9
-4g0w59+/iTHOE3M45quAw38K07/0BRznj5X0GuZ8G456t+IWjvnaK34nPqn+
-Xv6D6s/ejDHWK4fp/83Ufgpz3itewPG9VgVHv7XyNfLfwpznwbE+e9l3MOsP
-x/dPvfIPyp/9No2Xw7FeBcz9Ly7hyL+AY/4qmOtf3CjeVv6t6tnLv4N5/ot7
-xR/gSYy/S/Uc5vkHR74pzHm9/Bcwzz/pteI10rfK30rfizvZn2Ce/6pngPn+
-4/dpPznMeSzM+ksvYdYfjvyV9FrxGpjnn+K34j3M+a74JPse5vMf5vpv0npG
-cNSTw/H+NYZ5P4Qj3p38p+IZzPNT8efw5DYu4OhnqXor8UpcK/9a+RvpGzju
-v63y36v/Vv471b+X/UH2nfo/aj5Pyn+W3ivfRf0P6vcK8/73hxjjfXwER7wc
-Zv1lX8AR707+U+kz+Zdw7L/mMPtpOK7fpeqpFG+lfLXqWStfo3gbmPtR8e5V
-T6v8O5j3ddkflK8TH8Un+Z+Vr5f9RfaD+CrO/hhjzPcIjvi59DHM+YDs76RP
-xTNxCUc9c+VbyH4p+0r6SlyL1/JvpG/g6Gereu6lt/LfSd9LPyheJz7CnGfB
-cf5zFvfii/IN4qviZ39KeQRzHiYeiwv530mfimfiUv7zh/rtbyH7pewr8Upc
-i9fiRvE3yr8V38u/Fe/Ee/kfxJ3sj+KT7M/Se+kX8SC+irM/pzwS5+KxuBDf
-iadw1DuTXorn4oV4Ka4UfyW9lr4WN+KN/Lfie9m34p14/9D/Nh5g7n/xUfYn
-OO7fs/Re+kX5B9lflS97kNqPHqT2+YPUfiwuxHfiqeLNYJ7/sp+LF+Kl/Cvp
-K+Wrpa/Fjew34i0cz/N7cat6djDnlYp3kH2neEfpJ/mf4clt7GV/EQ8wn//q
-P/tLqo9gPv/FY5jPf5j1hzkvhqPemfRS8ecw54mqb6n8lXil+DXM+7+4geP9
-biP/rfhe9q30nfrda34Osu/ER/V7kn4W9+ILHPvNAY79wxVm//fXGGM+RnDs
-F3I41mMM83sZmP2feCqeKV4pnsOT27iQ/1JciVcw+2049kNrxW/U/0bxttLv
-VW8Lx/zu4Dhf2Cv/QfE7xTsq3kn+Z5jzPa3XRfUOindVvmyTxh/B7P+lj6UX
-cMS/g6O+Kcz6w/y+EI75msOT27hQ/qXiVdJXqqcWr1VfA8f8bWC+j1L8e9Xf
-Kv5O/ezFB+XrFO8Ix3nnSfpZ8XrpF/U3wHG+dVU/2Vup/+it1D6Ho78xzPcD
-4jv5T6XPFK+UPodjfhaKt5R/JV6pnxqO62UNs/6Kv4Ent3EL8/xXfa14p3h7
-1XNQvZ3qOyreSfNzVv298l0UfxBfxdnfYuT5D/P8hyP+GOZ8HI7vK+6kTxV/
-BnP/w9HPXPpC/kvVV8Fx3r+C4/6tYe5/caP4G+lb6ffK38KxPjv571XPAZ7c
-xk7+R5jvczQ/Z+XvVd9F+QbFu2q+sr+n8UbiHA7/MRzXQyH7O+lT8QyOekvx
-XLyA43pYwny/In0FR3+17NeqpxFvYJ7/MM9/2bfSdzDrD8f9fVA9nfIdZX9S
-/LPmpxdftF4DPLmNV8XL/pH2M4L5PhCO970xzO9jpN/B0c9U+kx6qXhz5V/A
-Uf8S5v6Ho/+V8tVw7C/Witco30a8Vbx71duqn53s97I/KH6neo7q56R4Z8Xr
-xRf1Oyj+VXr2z5RHcOw/cpjzf+mF9DuY81/Zz8QlHP3NYfb/ireUf6X8K/nX
-8l/Lv5H/RvVsNT/38m+l7xRvr/wH1ddJP8Kc/0g/S++lXxR/kH6FOf/9V6qP
-xLl4DLP+4juY/T8c9cwUr5Q+Fy/ES5jfV0pfwfzeTPoa5vxP8Tbirfhe/u1D
-/fa3k/1e9gfpnfSj+CQ+K18v/aL4g+yv4uzfKY/EuXgsLmDO/6VPxbP/838B
-1Gcb9Q==
-           "]]}, {
-          Hue[0.9060679774997897, 0.6, 0.6], 
-          Directive[
-           PointSize[0.005555555555555556], 
-           AbsoluteThickness[1.6], 
-           RGBColor[0.663226, 0.6872815, 0.9117649999999999]], 
-          LineBox[CompressedData["
-1:eJxdmjmQw1YdhzXQuHRB4YJC7DCMh2EYc5sz4goGAogEiCEQlEDAIUAM5HA4
-EhEuc7vcUqVLlS5VulTpUh1bqtySYfz/lnmfmzff/v7nezqf9h3Pvvj4c2/J
-suw/b82y/43X3/jIdXxfEX8oUp7EmMc4jXEe49tinGm8ifHtMb5TcW40zmRH
-nndJn4vfrTjvkf7eGOlroTz0if/7VecHYqTPD4o/pHwflv9HYmQeltI/Kv+P
-xUj/Hxd/QvafVPxPKf4jsi9ivLmONcx8fFo6TLzPpPY1TPzPxhjrVMOsw+di
-jHmtYdbh8zHGutcw6/ZojLHO9aOpffYF1S/OVmm+Gua4+aL8YY6LL8UY/dYw
-/l+Okf5h1uexGGM+68dS++wrMTK/4uyrqg/G/2vKDzM/ZRqvgKO+ukztO5j1
-+3oav4BZDzjidzDHz+MpF+IajvgdTP1PpPUU4vqJ1L6DWZ9vqH6Y+Ybxhzk+
-vxnjTfjD5IcjXwezft+KMa5bBUz/MP2LsydjjOOveDLVa5j8cNSbrdN+Cpj8
-MP4w59+303wFHP3UcOTrpGffSbmAmT9xJ/vsqbSeAuZ68VRq38HM33djjOO9
-gOlf3MGs3/divAl/OO4HNczxI86elj/M8QeTX/bZ99N+CpjrERz1dDDHfxVj
-zE8OUw8c9VQw8wtHfQ0c+Tv5D7LPnknz5c+keiGuYK5P4gbmfIGj3wFm/Z5V
-fnEBR78VTH444jWy7xRvgJn/H6Txcpj+pVfSazjiN7LvpA8wx98PY4zzJ4fJ
-L65g1l/cyL6DyQ9z/3su5RwmPxz+lfRa/o24Ew/yz36Uci4u4Dh/KpjzCyY/
-zPor3iD/7Mcp53A8ZxfSK/gm8osbcQdHPQPM8b+JkfMf5noCkx9m/mH6h+P5
-tIOjnwHmefn5NH7+fKoX4kr2NRz5GjjydXA87w/Ss58oP8z9AI74FRzvSbX0
-RvE62Q8w+V9I9fyFVC+kV9JrcQMz/9IHmPefn6acw5GvkF6JazjWp4GZf8Ub
-pGc/S/UcjvjFA19/lexrcQOTX/qg+NnPlR9m/sWV7Gs44jWy7x70628QZy8q
-P0z/0itx/WB//TXSO/Eg+2yb8lScw+G/kF5IL6VX0rcP+nWspR/k34hbcSfu
-xYN4FGe/SHkqzsULcSEuxZV4K65h+hc34lb+nfRePIhHcfbLlKfiXLwQF3Cs
-Zym9etCvv624lv9B/o30Fub8kt6LB/Eozn6V8hSO+DlM/+Liwf/6K8WVeKt8
-teIdpDfSW+mduJf9AMf9aFR/2UspT19K7XOY/mVfSC9h7hdw3I+28q+lH8SN
-4rfiTvl68aB8I8zzx8spT19O7XPpC5j3bTjqLWVfyX4rvZZ+UP5G3Mq+k96r
-nkH6CHP8v5LaT19J9RyO570FTP/iEuZ+CUe/W+WrxQdxI/9W+TrpvfwH1T/C
-PP++GuPNdZy+mtrncORbiAs4nq9LmPdl8Vb5avFB8Rs4nkdbcSf7HqZ/OJ7n
-R/WX7dL8012q5zDHv/QCjnpKmPMf5vhXvFp8ULxG/i3MfqK4h3nfEY/i7LXU
-f/paqufiBXxzHQv5l+IKjvnfwuyPKt5B+RrFa2H2w+Tfw7xvSh8VL/t1Wt8U
-jvpymPMf5v0IjvUrpVfStzDvb+KDuFG8VvV0su+lD3Dsb4zqL/tNjDHfUzj2
-93M45mcBs98MR7wSjvfpSryVfy39oHoa2bcw57/8e/kPqn+EWf/fxhjzM4Uj
-Xy59AbNfC3P8S6+kb2GOfzj2nw9wfFdr4OinhdnfU7294g3KPyp/9ruUpzD7
-ITDnv7iAuf7B7JeJtzD7u/DNdTxIb+Tfqr4Opn/5D4o/wux/v57Gm76e6rl4
-AXP+w1FfCUc9lfy3sq9hrv9w1NuIW5j9NdXTy36Q/SjO3oiR/mGO/zdS+wXM
-9xLZl3AcTxUc9W1hvs+ID+JG+Vs4+usUv4e5/olHmO/HdcoTOK6nUzjyzcQ5
-HPHn0hfipewLOPpbwZxP4rX8K8XfwFxvFH+n/mrF2yvfAY7j81Z6Iz7KvoXj
-efik+e5U71n19NIv6meA43i5k/+ofPfSs9+n9U9g3ofg8J/BPB/C0d8c5nlZ
-8ZbSC+kr5SvFa+WvxBv45jpu1d9O9rXq2SvfQf63sm9kf9R8tMp3UrxO+lnc
-a34u8h+U/072o/R76dmbKU/eTO2ncDzPz2Dej8VzxVvA0c9S9gUc7/Mr5Sul
-r8WV6t3Ifyveqb4aZv0V/6D4t+JGfFS+VnySfSc+y75/4OvvovoG2d+JR/G9
-/LM/pDyB4zeVPhPnsp+LF+KluHjg67hS/FL2a+mV/Dfirex3ileL9/I/yP9W
-3Mj/KG5lf5Leic/iXnwRD4p/J30U34uzP6Y8EU/FM3EunosX4qW4EK/EpXgt
-rsQbmO8N4p3sa/FefJD/rbiR/VHcik/y76SfpffSLw98HQfpdzD7fbK/V/zs
-T6k+EU8f+PqbwZz/4jkc+RfipeIX0lfiUryWf6X6NqpnK30n/1q8Fx/EtzDf
-O5XvKG7huL6fxJ36Oyt+L/uL6hmk34lH9X+vfNmfU56IpzD3f+k5HPXOpS/g
-qGcJ8/wPx/13JftS+lpciTeqdyveqb5a+fbwzXU8wDz/iRvlP2o+Wjie30/S
-O/FZ8XvN10X6oPx36m9Uf/eyz/6S1jeBI/4UjvpmMN+HZD+Hb67jQrxUvkL+
-K8Uv4eh/rXgVHO9DG5jvTeKduFZ/e9V3UPxb5W9U/1Hcqv6T8nWKfxb3quci
-/0H57uQ/yv9eerZP65vsU30Kx/vlDL65jjkc+ydzOOpZwLEfsoT5/x7lX4lL
-8Vr1VHD0t1F9W/nvpNeqf6/4B9nfan4aOPZ/jsrXyv8k/072Z81XD8d+00X9
-Dop3p/pH6ffqN/traj+Bo94pHPXNYL6PwFHvHI75WCjeEmb/UP4r1VOK13Ds
-R1eKvxFvZb+TXqufvfId4JjvW5j3f9V/lH8Lx3yfxJ3m66z57mV/Uf2D+E75
-R/V3r3qzv6X6BI78Uzjiz2Sfw1H/HI56F3Acv0vZF4q/gll/xVvDrL/ibZRv
-q3g7xavlv5f9Aeb+r/lpFO8ovZV+gvl/es3nWfPRy/+i+gb1eyd9hLn+K372
-97SeCcz6w9H/DOb+L/+5/Bdw9LeE+f9SOPpbyb5U/DXM91XpGzj628p+p/i1
-6t2rvoPqu5V/I/uj8rWq76T57BT/LL1XfRf1Nyj/ndZnlP+9OPtHaj+BI/5U
-+kyci+cw93+Y/T9xAbP/r/wlHPO5ln8l3sB8b5X/Dub5T/571X+Q/y3M9xnV
-e4R5/le8k+J10s+qr9f8XqQP4juY53+Y93/Fy/6Z1juB2f+VPpOew+z/wpFv
-IX0p/0L2K+UrxWvZV3C8b28Ufyv73QNff7Xq28v+oHi30hvpR3ErPok71X9W
-Pb30i/RB9dyJR/G95jP7V6pPxFPx7IGvvxyOfuYw/y8o/6W4kP1Keil9La5k
-v1E9WzjmayeuFW8v/SD9Vvka6UdxK/uT5q+T/Vncy/4ifRDfyX5U/ntx9u/U
-fwLHbyqeyT6XPhcvxMv/838BklUXBw==
-           "]]}, {
-          Hue[0.1421359549995791, 0.6, 0.6], 
-          Directive[
-           PointSize[0.005555555555555556], 
-           AbsoluteThickness[1.6], 
-           RGBColor[0.941176, 0.906538, 0.834043]], 
-          LineBox[CompressedData["
-1:eJxd2zuw80YZxvEdaFyqoHBBIc4wjIdhGHE314i7uSvhEhMu2YQETCCJuAQM
-gbAJNxNIUOlyS5cqXW7pUqXL7XCp0iXDaB8x+1ej+eV533dX0rGPzzlf3vH0
-i489+xZjzH/easz/ztMxPjKdizr9h3R+Wzov0vntdV6nPtUtcVad+jS3lNPx
-gHXeCb8L+1lhnXdj/nvQ/17kFfw+7Pf96P8A/EH4Q/CH4Y+ks+7XWuun46PY
-z8dQ/3H4E9jvJ+FPwY/Adb4/B5tP5/VO1v3/TL5fB5vPol/W8/pcPs/JWv/z
-6Jc1/wvYv6z5X8ztZO1/k87p69Jt8nrzJfTL2t+Xkcva31ewP9h8Fbms5/u1
-fJ6DzdfTWfcHNt9ALmv9Jt9/Let5wEHW/EfzvH40z52c9htQbx7L62tZ9+Ox
-vD7Ieh/5JtaHnZzeZwJy8618vRp2ctpfkHX/v53Oun+y+uEg6/59R/PSVNjB
-QdbXx+PYv6zrfzyvD7K+vrfol/V6kHX9sPluPr+WtT4cZL3vP5HPq5/I652c
-9htg8718v7Ws+w8HWfv/fp7XcroehzzA5gfol7V/5AG5+SH6Zb1+ZL1+UG+e
-VJ6qnszrnaznL6vf5i7l1F/DFvUOuUce4Ih681Q6p+stn8rra9jKur+wR32A
-I9YzT2N9uJZ1/bLe72WtjzxgXsQ88yN5OkpZ1y+n+RZ2cnq+fp6X1se8iNw8
-k/eXz+R5Lev+o97BXtbrHf0RNs+ms+6/rPeTZ/N6K+v6YY95AY6yrv/HuUtZ
-68taH/UOuUce4Aibn8jTUcp6/rCV9f4w96f14QBHWe8/u3TW84drWV//yB3s
-4SDr+WOe+SnWh2tZ14/cyel+eFmvP1nXD5vn8v5SVtVzeb2VtT7s0R+QR9j8
-LHcpa1XYot4h98gD8jg7nX+eu5yd/ityCzvUe1nry3r+yM3zeX/5fJ7XyC3s
-YA8HzIvIzQt5XsL1C3m9nT2dHXIPBzjC5sXcpaz153w6W9Q72MMBjrBpcxdw
-CVey9oe8gS3cot8h72AP93CABzjCI2x+kbuAS7iCa7iBLdzCDu5gD/dwgAc4
-wiNsfpm7gEu4kvX8kTfILfIWuUPeIffIezigfoDjXD+dR/SbX+X1BVzClayp
-cIN6C7eod8g75H72dO5RH+AB9RH5KOvz16/z+mL2dJSyrh+u4Qa2mNfK+vkB
-9R3qPdxjvwH9AxzhEf3mpTwv5HSUL+X1FeprOV1PA1u4Rb/Deh1yj/V75AEe
-MC+if4TNb/L+QtbPg3Al6+cD5A1yi/ktcgd3sj7PIe/hgPkD+iPqR9Sb3+b7
-L2R9HpTT7xcq5LWsr39Z14/5LeY55B3sMa+Hw+zpGJBH5CP2a/b59RSynj9c
-yXr+6G/k9Pnbor6V9fWP+R1yj/m9/DCdA/oH9EfkI/ZjfpfnhaznL6eflyq4
-ltP1NnJ6vhbzW9ihv0Pu5Yfp3CMP2M8g6/njekasZ36f9xeyfh6Q9fxlvf+h
-vpHTehb1LeY5Od2vDrnH/npZv8+VH6bzgPqI/Yyyrv/lfF7xcl5fvpzXV7Ke
-v6zrl/X+j/oW8xzcod9jfo88yHr/w/4j1h8xz/whzwu4lNO8Cnktp/vXoN7K
-6fpa9DtZzx+5R3+PPCAfZP28ifkj6s0f8/pC1vOX9fpHXsMN6q2c1m9R77B+
-B3tZzx95QD7AcfZ0jMjNK+ms7/+v5PXlK3l9JevvHXK6vgb1Fm5hJ6f70cl6
-/livl3X9WH/AvAiPWN/8SU5lsj7/y3r/k/X8kTfIraznj9zJ6Xq7eT/T2cM9
-HLDfAdcTUT/CxuX7X8jpfhfIl7K+P8hp/RXyCl5jXi2n+7GBG/Rv0W+x3x3y
-Ft5jvsP8A66nQ/8R9qg/YV6P+jMc4As8YN4Vjqi/YT8jfJ/70/Fqni9ezfNC
-Tl+fS1mfD+V0P1dz/3SuUL/GejXqN3CD/i36Lfa7g1vU7zHfwQe4Q/8R8z3y
-E/Ie+Rn3KyC/YP0B9Vfcj4j8hnkj9nPHfPNaPm8h6/vBa3n9EnkJr+Bq7p+O
-NfIa3sAN1t/CFvU7XE8rp/uzR73D/g6o77DeEf0ePqG+x37OyAP6L/AAX+GI
-/d/gEb7D5s+5F3ABL+ESXsEVvJb1/JFvkDfwFrbo38EtvIcdfIA7rHdE7uET
-3MNnOMAXeICvcIRv2O8I31Fv/pJ7ARfwEi7hFVzBa7iGN3ADb2EL7+AW3st6
-/SM/IO+QH2EPn+AePsMBvsADfIUjfINH+A6bvybr+z9cwEs5HSW8giv0r5HX
-yDfIm9nTeYt6C+/Q3yLfww4+wB3mHWGP/Z3gXtb7P/oDfIEH7OeKPGK9GzzC
-d8wzf8u9gAt4CZfwStbnP3iN+nrOp2OD+gb5FrbwDm7hPdZ3WO+AvIOPqPfw
-SU7Pu4fPqA/wBesN8BXXE5HfMG/E+ndZ//7j7+mcPu8sZP09CF7CpaznD1fw
-Gq6x/kZO+2tkff7H+hbzdnCL+j3mOax/QH0HH1Hvsd8T5vfwGf0BvmD/A+Zf
-sZ+I+Tc5/Tw8Ir/D5pDPX8j6+R/5Uk6/zyjhlazfF8p6/WNejfoN1m/gLeot
-vMN6LdbbI3ey3v/hbq6fjiP6PXyCe+z/jP0E5Bf0D9jPFXnE9d8wf0T9HTb/
-yPsXsn4fLOv3P3AJr2T9vlxOvx9ey/r3ulh/g/oG87bYn8X6O1nPX9b3f9Q7
-1B+Qd8iPyP2cT8cJ++3hs5z+v5YgP0znC+oHrH+FI3xD/4j7e0e9eT3PF6/n
-eYF8Kev5o34FV3Lazxr9tZye5wb9DfIt+i32t8N6rfwwnfey/v6KeQdZr3/k
-R+R+3u90nLB+j/4z9hsw74LrHXA/rth/RP0N80f032Hzz3z9hay/h8h6/rL+
-PoT+FeorzFvLD9O5ltP1bDC/gbeYbzF/h7xFvocdfMB6HeYdYQ+f4F5O9/ss
-69+nYv0LPMBXzIuzp+OG+hHr3ZGbf+VeyPr3ALK+/8vpKGdP5xX6K8xfwzW8
-QX+DfAtb1O+wnxbeo97h+g7IO6x3xDyP/IR5PfKzrH+/g3kXrD/AV9RH+AaP
-8B3rmzeUp22+kdcXb+T1S7hE/wr9FbxGfw1v4AbeYp5FvoNb7G+P3MEHuIOP
-sMf8E9yj/gwH+ILrGzDvCkf03+ARvsPmzXy9BVy8mdcvZX3/h1eyXv/I15hf
-wxu4wfpb5Bb5bs6no4X3qHfwAe7gI+Z55CfkPXxGfUB+gQf4Ckf4Bo/wHTb/
-zr2Q9fsfeIn6El7BFbz+v/8LvN4eZQ==
-           
-           "]]}}}, {}, {}, {{}, {}}, {{}, {}}}, {
-      DisplayFunction -> Identity, PlotRangePadding -> {{
-          Scaled[0.02], 
-          Scaled[0.02]}, {0, 
-          Scaled[0.05]}}, AxesOrigin -> {0., 0}, 
-       PlotRange -> {{0., 999.}, {0, 24.}}, PlotRangeClipping -> True, 
-       ImagePadding -> All, DisplayFunction -> Identity, AspectRatio -> 
-       NCache[GoldenRatio^(-1), 0.6180339887498948], Axes -> {True, True}, 
-       AxesLabel -> {None, None}, AxesOrigin -> {0., 0}, DisplayFunction :> 
-       Identity, Frame -> {{True, True}, {True, True}}, 
-       FrameLabel -> {{None, None}, {None, None}}, FrameStyle -> Directive[
-         GrayLevel[0.5], 
-         Thickness[Large]], 
-       FrameTicks -> {{Automatic, Automatic}, {Automatic, Automatic}}, 
-       GridLines -> {Automatic, Automatic}, GridLinesStyle -> Directive[
-         GrayLevel[0.5, 0.4]], ImageSize -> 750, 
-       Method -> {"CoordinatesToolOptions" -> {"DisplayFunction" -> ({
-             (Identity[#]& )[
-              Part[#, 1]], 
-             (Identity[#]& )[
-              Part[#, 2]]}& ), "CopiedValueFunction" -> ({
-             (Identity[#]& )[
-              Part[#, 1]], 
-             (Identity[#]& )[
-              Part[#, 2]]}& )}}, PlotRange -> {{0., 999.}, {0, 24.}}, 
-       PlotRangeClipping -> True, PlotRangePadding -> {{
-          Scaled[0.02], 
-          Scaled[0.02]}, {0, 
-          Scaled[0.05]}}, Ticks -> {Automatic, Automatic}}],FormBox[
-      FormBox[
-       TemplateBox[{"\"M\"", "\"R\"", "\"S\""}, "LineLegend", 
-        DisplayFunction -> (FormBox[
-          StyleBox[
-           StyleBox[
-            PaneBox[
-             TagBox[
-              GridBox[{{
-                 TagBox[
-                  GridBox[{{
+ TagBox[GridBox[{
+    {
+     RotationBox[
+      StyleBox["\<\"Male\"\>",
+       StripOnInput->False,
+       FontSize->30],
+      BoxRotation->1.5707963267948966`], 
+     TemplateBox[{GraphicsBox[{{}, {{{}, {}, {
+            Hue[0.67, 0.6, 0.6], 
+            Directive[
+             PointSize[0.006944444444444445], 
+             AbsoluteThickness[1.6], 
+             RGBColor[0.293416, 0.0574044, 0.529412]], 
+            LineBox[CompressedData["
+1:eJx12jlw9VYVwHENlUsVFC4oxBsm8w3DMGI3ay6ExRAWETazi0CCQwgRZMGE
+7UIIcflKlypdqnSp0qVKlyrdMKPSJTDv/D/m/mf4itz5+Zx77iLpPUkv7372
+5Weee0dVVf/6z3/+2x7+bU8e2ven+EO0u2iPom2iraN9Itp3Kn4sv+v//P09
+Gsd/x0/o748Uf6/i75NZF+O0qvsB1f2g8j+k8T4cLev5iPp/NFrW/THVO9H8
+Pq55fULr+KTm+Snlfzpa1vkZzftJ9U9lfsas+7OlM2a/Plc6Y47DU6XzU2V+
+9floYz8zZr++EG2sP2PW+8VodxHHjP8lzU+uTqON45Yx+/Xl0hlT/yvlfDJm
+f5+Olv17WvGvanxM/a9Fy/HBnA9fL/MzZn++of6Y/l2ZnzD1cOzXjDm/vlnW
+S3LGUX/GXDfPRBv7kXBcJxnHeDPm+Hwr2ti/hNlvHPVnzP58u3TCHG8c1/OM
+Wf93oo39Sjiu+4zZP0z/72r+OOabceznjDk/vlfmp++V+VnxGTP+WbSx3oRj
+vVnxWa6+H23sd8IcP8VnzPH/QbSsH3P+YcbHnL8/1Pwxxx9HvRlz/f+orJcw
+61d8xnzO/7isn3B8nmd5xpx/P4k2zpeEWT9m/zDz/2m0cTwTpj/m+Cte9aUb
+TD0c6+9xfD5necSc7zjGXzHfdz+LNs6HBnM8cMyvlzOO/Rwx61X9FXP+P1vW
+azDjyz3exfjyiDne8qr86ufRxvdfgxkfx/nYYz4fcJw/I+Z8V70VM/4vSjc4
+5pPkXvlZHnGcDzOO/V4Vr56LNs6XBvN5jGP/eszxx3E9jqo3q96qePV8tHF9
+NTjGS8+X+T3exfiKjzjui2cc98Ur5v7xl6UbOWHWjxkfc/0pPuO4P12VX52X
+bnDMP+GYfy9neVT/WfFVrl6INp4rmhfKeJJ7vIvxcezXiGO9M471rRqv+lU5
+30ZOci9nzPox4yu+qn/1YhlvXizjCcdzWK/8jFm/4rO8Ytb/69KNnDD7r3jG
+Mb8Rc/yVv6pe9VKZ37xU5ifM+uWs/FH1ZhzPtavi1W/KeIOjfsJRv1c8y6Pq
+zYqvmPFfLuMNjv5J7uWs/iOO+c6P44d/q/KroaxXD2V+o3grJ+V3ci8P6p8V
+38ujPMmzvMirvMnVb0vXciO3cpI7uZcHOePYj73iozzJs/ov8ipv6l/9rnSN
+uR7k9nH+oU1yp/xeHuSs/nvFR8UneZYXecVxPWyKV6+U8fqVMt7guF5bxROO
+75dO9XrM+tU/K75XfJQn5c8ab5FX9d8Ur14t69WvlvFG8RazfuV3mO9LxQf1
+z4rvFR9xfF9Myp9xfP8tmO979d/Uv3qt7F+/VsYbHN/nLeb+BHP81b9X/0H5
+WfG9PGq8Sf1nvDu0i/qvOI7Hpnj1ehmvMet/vcxv5aT+HeZ+QfkDZv047p/3
+mPsZHM8/E94d2lnjLaq/qt6m+VS/L+vXOOo3ireY+3MczyMdjuezXvFB/bO8
+x/G8NKrepPnMyl8wz5saf5Ori9I15nkEx/it8pPcYZ5XcMx3wBx/HM9ne9Ub
+1X/CvA/SfBflr/ImV38o11dj3gco3mKeT3E8X3c45tfjeL4clJ9xHL+9xh9x
+XB8TjvcZs/IXxVfNf1N+9UY5n/qNMt7gWG+LYz5J/Tu8O7S9+g+KZ3mv+qM8
+abwZx34v8orjd5UN8/vGH8v51Zj1K95i3rfiGK9Tfo/j+A6Y94OK7zHvM/Du
+0E6Y9xs49mORV61n0/yqP5WucfRvcIzXKp5wzL/DvK/CsT+D+mfM5x/m/Fe9
+Sf1nzW+RV/Xf1L/6czm/Gsd6GsVbzPtuzOcfjvOtx3G+DJjfezCff/Ko+UyY
+9St/Uf6q8TfNt/pL2b/GvA/DfP9h3o/h3aHtlN/jmO+g+hnz/Y/5/sOx/xPm
+/a7ii9azqv6m+VR/LfNrHOtpFG8x78dx7EeHWb88YM5/1d8rf1R8UnzGsR8L
+5vzH8X54wxz/XNY/wtG/xnF9HssNjvU/Uv9W8RO8O7RJPlV+h2O+Z4r3ms+5
+xh9w7PcF5v05jvPnUuPttT9XGn+Ur+VJ67uRZxzH81brWZR/p/xV672XNxz3
+uw+qX/2trH+EOf441nOMOf6KP8JxfbQ47s9PNF7CMb9TxTsc6z1TvJfP5UG+
+0Pyzxr+U95r/leqNqneN4/lpUv8bzPObxrtVfMHxfHUnr+p/r/lsyn9QfvX3
+Mn4k1zjWc4w5/oo/wrHeFsfz/InqJ+Wfyh2O+Z6pXq9655rPoPiF6mfFL+W9
+6l3Jo+pdq/8k32B+H8BxvG8x77PkO3nVfO4V3+QHzP/n9WYZP3qzjNeKH8sN
+5vjLreqdyEk+Vf1OPlN+r/i5PCj/Qs6P8w//LhXfy1eqP8rXyp9U/0ae5Vt5
+ke/kVb6XN/lBrv5R+kiu5WO5kR/JLeb4K57kU+V38pnye8XP5UH5F499aLPy
+L+W9fCWPqnctTziuhxv1n+VbeVG9O3mV79V/U/xBrt4q53ck12+V+ceY3+sU
+fyS3yj/BvD+VT+UOx/fNmer3mu+5xhsUv5Cz8i8x3/+azxXm93bVu9b8JtW/
+Uf1ZvpUXjXen8Vbl32u8TfN5UH71z2hjfUdyjWP8Y8zxx3z+Y94XK/9E8aT6
+p3KH4370DO8ObY/j/vNcHpR/gfn/uzTeJeZ9hOpdqd4oX2v/JtW/kWf1v5UX
+7ded5r8q/177tWn+D4pXb5f1jjC/h7xd5h8r3mDu/3E8P7U4nr9OcKw/afxT
+jdcpfib3Gv/8f/P7N6EudRo=
+             "]]}, {
+            Hue[0.9060679774997897, 0.6, 0.6], 
+            Directive[
+             PointSize[0.006944444444444445], 
+             AbsoluteThickness[1.6], 
+             RGBColor[0.663226, 0.6872815, 0.9117649999999999]], 
+            LineBox[CompressedData["
+1:eJx12jlw9VYVwHENlUsVFC4olDcZxsMwGSVsZo1YY8L2+NhMQkAJhDgLiVhj
+IITLGpevdKnSpUqXt3Sp0qVKN8yodAnMO38z9z/DK3Ln951zz10kPT3Jeeyl
+tx69/L6qqv71n//8t91/1qf37VNd/EO0T0Z7EO3j0dby+6Ntoj2M9gNqN8pr
+/s+/P65//6DGOdK8PqT4hzXPJ5TfKv9J+Sn5I6r30WhZ58eiZZ0f17w/IR+r
+/iejZd2finYT7aejZZ2fUb3PKv9z8tPRsm9dWS9h9v/zZf+EGe8LimP254vR
+xnmUMPvzJfXHjP/l0gmz31+JNo5zwtR/JtpYb8LM/0T95eqr0cZ5kzDnzbPR
+xnmSnlX8a9HG8UyY8b+u8THH5xuKY87jb5b1klx9q6yX8CbabRnvMPuNY/4Z
+0//b0cZ+dziOT8JRL2Pm9yjaOP+6R2U84biOMua6+060sR8djv1POPYvy9V3
+y/l1mPHxJvpjrs/vlfmdnDDjK159v6zX4RgvyRlzfvwgWvYPs34c42XlV6fR
+cvxOy/yEOX6Y9f9Q88fMX/GM2f/n1B/H93B6rszPmPP/+XJ+3fNlfsKxXxmz
+/z+Klv3DXK9yxuz/C6W7F8r8JGe5+nHpDjN/zPHDjP8TzR/TH8fxzZjv1z7a
+zb5tcNyPOsV7zPmB43ofMePhGG+RqxejjfU3cif3mPXhqDdixld8wZw/L5Vu
+MMdT7jHj402ML2fM+Jj740/LeINjPzsc6+kx+49jf0Yc68k45r+of/UzjY/Z
+f8z4clL+iDlfcfzeWjRe9XK0sd4G832EYz095n6GNzE+ZnzM/qt/9fMy3mCu
+Jxz1exzXR8Kc/3LGcbwXzO/PV8p4g+PTvVLm95j9x5z/OOaX1X+Rq7Nyvg2O
++XQ46vXKT4qPcsaMr/rVqxr/1TK/w4yveFJ8xNyvMPuv/Oq1Mt7g+L3avVbm
+95jx5VH1suKL4tXr0cZzV/N6md9hxlc84ZjvqHhWfFG8eqOMN3L3Rpnf45h/
+UnyUs7zI1S/Keg1m/AfvP73iCTO+4lleMM+5b5b9G7l7s8zv5SSPcpYXzOet
+0o3cPXjf9nJS/ihnzPiKV0PpWm7kVu5w1N/KvfIHOck7eZQnOcuzvMirXP2y
+dC03cit38lbu5UFO8k4e5UnO8ow53vIqV78qXcuN3OL4dIpv5V4eHvrv26T4
+TvFRnpSf5Vn5i7xivn9/XcZrzPcBZv1yJ2/lXvUHxZO8e8jff0Z5Un5WfJYX
+rWfVfKrflPVquZFbuZO3mO8reVB+wjG/nTwqf8LcX1V/xnG/XFRvxbw/+m3Z
+v8bRv8ExXou5P2DWr/49jvEGxZPiO81n1HiT4lmelb8ovmo91e9K15jzH0f/
+FvN8iGP+W/XvlT/ISfV3mN+zOJ4vJo2XlT/jzb5dNN6KeT/4djl+/XYZb3DU
+b3HU7zDrxxx/9R8w7wcU38mjxpsUzzied2bM857iK+b597ysX2Oex3Ecz1bx
+Tt6qXo85/5WfcMxvJ4/yhHm+x/G8Nqv+ovmsile/jzb2s8Ycfxz71WLe92HW
+j+P9QI/jfeWAeT+n+A7HekYcx3PS+FnxWetZ5BVvov1DtHF8ahz1GxzraRXv
+MOtXvMcx3qB4wjH/HY79HzX+pHhW/1leNL9V9ao/lvk1juPT4OjfYt4P4Hj/
+v8UcfxzzHTDrV70d5n2C8iflZ7zZt7Pii+Ir5v3LO2W8fqeMN4q3inc41rfF
+vC9T/0HxhFm/8kd5wpz/ms+Muf8rvmLuf38q51/jmE+jeIv5/sOxni3m/Fe9
+AfP3JMV36j/izb6d1D/jOF9neVH/VfWrd6Nl/TjW07xb5rc46nWY61/1euUP
+iicc18tO+aPqT5pfVr1Z8UXzX1Wv+nOZX+P4+0OjeCt3OOpvFe9xrG/A3P8w
+9395xHF+TKqXNf4sLzj2Z1X9KpX5B6mM13izbw8x90cc19OR8lv5GHP9aLwT
+1dsqfopjP3rFz7SeQfFz9U84jtcFjutnp/le4tj/Ub7SeJPqX2s/svJvtL+z
+8m/lRfO7k1fVu9d41V9KH+D4/qxx3I8OMb8PFT9SvRbH99Ux5v0+jvWcKL5V
+/FTxXuOfyQOO8+kc8/5U+ReY5xHFLzHv+5R/pfxJ+dcaP2u/bxSfVe9W61nk
+O/Vf5Xu5+mvpA8zzkOKHmOdjzPFXfqv8Y8W7h/H2nxONv1X+KY719jj290z9
+B/U/l5PqXSi+U/xS8x01/pU8ydeYv49ovjeKz/Kt8hfN507jrcq/l6u/lfkH
+ci0fYt7X46h3pHir/sdyp/wTxbeY46/xeuWfyYPyz1UvKf9C3smXD/X2n1G+
+kif1v1Y8K36j+Czfyot8J6/yvVz9vfSBXMuHciMfya18LHfyibyVT+VePpMH
++VxOmOMv7+TLh/77dlS9K8Un9b9WPCt+I8/yrbyo3p28Yr7/5eofpQ/kWj7E
+XP+Y61/xFvP9j/n/G5R/onpb+VT5veJnmu+g+Dnm/bPiF/JO9S4VHxW/UnyS
+r5WftT83Wt+s/brF8ftnwfF7607xVfXvNZ/qn2X8APM+GHP8MX+vV/8j9W9x
+/B4/xvz+xzGfE9XbarxTxXvN70zxAcd+nMtJ87nAPI/hzb69VHxU/EqeNP9r
+OWs+N4rPmt+t4ovWe6fxV833XuNV70Ubx+tArt8r8w9x1G9wzO8I8/sPx3yP
+Va9T/ETxreqfan69xjv7X71/A37PbmU=
+             "]]}, {
+            Hue[0.1421359549995791, 0.6, 0.6], 
+            Directive[
+             PointSize[0.006944444444444445], 
+             AbsoluteThickness[1.6], 
+             RGBColor[0.941176, 0.906538, 0.834043]], 
+            LineBox[CompressedData["
+1:eJxd2Ttw7kYZh/EdKpcqUrigEGcYxsMwjLiba8QlYO4f4RIT4KAEAiYEIq4x
+kMAmQHCp0qXKU6p0uaVLlS5VumFGpUtgtI+YfVRE88v/3Xd3JX3yZ593vfjq
+sy+9I4Tw7//+53/n7Vif3s7Hbf4fbemjfH4qnyvVPSV73DvlWn6kvu9uy3W9
+Rz7R+Pcqf5/8fq2zUf4B+YPaz4c034eVf0TjP0qej4+p/jSf2e/H1f8T+cx1
++6TqP6X6T6v+M5rvaa2nLdcbW+WfVY7p97l8ztczYu7758v1Rsx6v1A6Yu7P
+M+V88ZmyPnxR4zHX50uaH7P+s3xmf3L4subHrO8rmh8z/qvZ+XpEOXxN4zHj
+v671y+Eb5Xoi5vp8U+vH9D+Q56pDmUflSQ7fKutbOeK8niSHZ8v1tZj9Kk+Y
+98a38zlfzxbn5z/ivJ6Emf87ZX2LuV84X9+EeX6+W+Yt5n4qT5j7972yvsXc
+L8z6VR+eK+vb58o84jxfksN5PnP9MNdPeZLD9/M5v6dbnO9PxLlfwnx+ntf8
+z5d5xKxfDj8o61s5YtavPPwwn7n+mOuvPMnhRxovR8zzqzw81vofl/XxcVmf
+5PBjzY/ZP2b/mOe3K13jfH1b5R1mfzjPN8pJ4xfM8/NC2a9+ocxb/CjPrzxq
+/Ih5XnB+/haNDy9qfsz9UN5h3m84729UnjR+wcz/k7K+xnyecd5PpzzKI+b6
+y4v6hZ+WrjHvc8z+MfNr/Kg8afyi+vCS5se8j3FeT4d5/jD7V57Ub9F84Wdl
+/xpz/XG+Xx3m55M8Yq4/Zv+aL/xc82PmV97t+XZE5aPypH6L6sOF5se8T5R3
+mPmVj3u+nZO8aHz4RZnXcit3csTMrzxhrr/y8HKZ1y+XeYvZvxzlcR+/HUn9
+FtWHX5b1tdzK3e7tHOUR8/6RF/ULr5R5LbevlPWd8oh5/ypP8qJ+4Vela7nF
+XH85qn6U0+7tvGh8+HXpGjNK7uSo8aPyJC9yeFXzY54/5Z0cVT8qT/Ky1+ej
+L13Jtdxgng/lB7mTeznKgzzKk5zkWV7kVQ6/KV3JtdzIrXyQO7mXozzIozzJ
+SZ7lBef7te55Pv+2zCucj1pu5FY+qF+359u5V32UB40f5Un9kvJZXtR/VR5+
+V7qSa7nB/HyUD5jva5j9q1/c8+0Y5FGe5CTP8iKvcvh9uZ5KruUG56NVflDe
+yb3qo/JB+ShPqk/yLC843591z/P5D6Urud69HQ3m/Ye5/5j7r369HOVB/UbN
+N8lJnrXeRf1X5eGPpavd27nG3H+5lQ9yJ/eY7+84f18eNP+o+klO8iwv8iqH
+1/I5369Krl8r6xvM7yeqP2B+X9D4XvURc/8xz788YX6/0PhZ8y84/z1m1fzh
+stxPhfk+LDeY+y8f5A7n+Xo5qv8gj/KE2b88q37RfKvqw59KV/jRdq5xvr4N
+5v7jfL0Pqu8w91/jo/JB/UbVT+qfNH7Wfhblqxz+XParMO//Pd+OBvP3Icz7
+T+5wXk+P+fug8gHn/Y7qN6k+aT2z8kX9VszfX/6Sz/z8w7z/lDfKW+UHzPtf
+7jH71/hB/UfM/lWfMM+/6hfM/lUfXi/XV71e1teYzz9m//IB8/nX+F6Oqh+U
+j1rfJCfM/jV+0fpWjQ9vlHn1RpnXOD8vDebzr/yAef4xz78cNX5QPuL89/VJ
+9Umetf5FXrW+8Ndyvgrz/CtvMJ9/zOdf4zu5l6PGD5j3n+afND6pfsZ8/1f9
+qn7hb2VeyTXm84/5/o9zvwPm869+veqj6gfM/jXfpPFJ/Wetd1G+anyIZX4U
+y7zCef5j5TXO6z/BXC/1P5Xb3dtxpn4HzX8udzh/Hi80f69+l8qj9nOlfNB8
+16oflT9RPqnfjZy0vlt51vW50/Vb1O9e+ap+D1pveLP00ZtlfYVzv2PltXyi
+fo3yU8y/r8hnqj/s82/Hufp3OO//QvW9fKn9RI2/kgeNv5ZH+Yk8ab036p/k
+W61v1vg7edH4e82/qt+D6sNbpY/eKusrzOdfrlV/sns7GvU/Vd4qP5MPqj9X
+3skXqu+VXyqPu7fzleoH+Voe1e+J+k04P883Gp/kW42fld9pvkX5vfJVfpDD
+30sfyRXO/Y+V18pPlDe7t/Op3Kr+TPlB/c+Vd/KF+vXypRzV/0r5IF+rfpSf
+qH6Sb1SflN/Ks3wnL/K9vMoPcvhH6SO5ko/lWj6RG/lUbuUz+SCfy518Iffy
+pRzlK3mQr+URc/+VT/KNnORb9ZuV3+3ezovq7+VV4x/k8M/SR5jfh+Vjucb8
+/Jcb9T+VW9WfYb5Pa75zzM9/5RdyL1/KUb7S+gb5Wh7lJ+o3yTeqT8pv93w7
+z6q/U74ov5dX1T9ovvB2WX/0dplX8vFev51rnO/Hidxo/KnGtzj/PeQM8/u0
+6s8xv1/JF3IvX6pflK+0/kHX51r5qPyJ9jup/kbzJflWntXvTvmi/d2rflX9
+gxz+VfoI8/sf5v7L9T5+O04w91/5qeZr5TPM93/l5+rf4fy8XPx//H8AVD2B
+Pg==
+             "]]}}}, {}, {}, {{}, {}}, {{}, {}}}, {
+        DisplayFunction -> Identity, PlotRangePadding -> {{
+            Scaled[0.02], 
+            Scaled[0.02]}, {0, 0}}, AxesOrigin -> {0., 0}, 
+         PlotRange -> {{0., 749.}, {0, 50}}, PlotRangeClipping -> True, 
+         ImagePadding -> All, DisplayFunction -> Identity, AspectRatio -> 
+         NCache[GoldenRatio^(-1), 0.6180339887498948], Axes -> {True, True}, 
+         AxesLabel -> {None, None}, AxesOrigin -> {0., 0}, DisplayFunction :> 
+         Identity, Frame -> {{True, True}, {True, True}}, 
+         FrameLabel -> {{None, None}, {None, None}}, FrameStyle -> Directive[
+           GrayLevel[0.5], 
+           Thickness[Large]], 
+         FrameTicks -> {{Automatic, Automatic}, {Automatic, Automatic}}, 
+         GridLines -> {Automatic, Automatic}, GridLinesStyle -> Directive[
+           GrayLevel[0.5, 0.4]], ImageSize -> 750, 
+         Method -> {"CoordinatesToolOptions" -> {"DisplayFunction" -> ({
+               (Identity[#]& )[
+                Part[#, 1]], 
+               (Identity[#]& )[
+                Part[#, 2]]}& ), "CopiedValueFunction" -> ({
+               (Identity[#]& )[
+                Part[#, 1]], 
+               (Identity[#]& )[
+                Part[#, 2]]}& )}}, PlotRange -> {{0., 749.}, {0, 50}}, 
+         PlotRangeClipping -> True, PlotRangePadding -> {{
+            Scaled[0.02], 
+            Scaled[0.02]}, {0, 0}}, Ticks -> {Automatic, Automatic}}],FormBox[
+       
+        FormBox[
+         TemplateBox[{"\"M\"", "\"R\"", "\"S\""}, "LineLegend", 
+          DisplayFunction -> (FormBox[
+            StyleBox[
+             StyleBox[
+              PaneBox[
+               TagBox[
+                GridBox[{{
+                   TagBox[
+                    GridBox[{{
                     GraphicsBox[{{
                     Directive[
                     EdgeForm[
                     Directive[
                     Opacity[0.3], 
                     GrayLevel[0]]], 
-                    PointSize[0.1], 
+                    PointSize[0.125], 
                     AbsoluteThickness[1.6], 
                     RGBColor[0.293416, 0.0574044, 0.529412]], {
                     LineBox[{{0, 10}, {20, 10}}]}}, {
@@ -382,7 +364,7 @@ zr2Q9fsfeIn6El7BFbz+v/8LvN4eZQ==
                     Directive[
                     Opacity[0.3], 
                     GrayLevel[0]]], 
-                    PointSize[0.1], 
+                    PointSize[0.125], 
                     AbsoluteThickness[1.6], 
                     RGBColor[0.293416, 0.0574044, 0.529412]], {}}}, 
                     AspectRatio -> Full, ImageSize -> {20, 10}, 
@@ -394,7 +376,7 @@ zr2Q9fsfeIn6El7BFbz+v/8LvN4eZQ==
                     Directive[
                     Opacity[0.3], 
                     GrayLevel[0]]], 
-                    PointSize[0.1], 
+                    PointSize[0.125], 
                     AbsoluteThickness[1.6], 
                     RGBColor[0.663226, 0.6872815, 0.9117649999999999]], {
                     LineBox[{{0, 10}, {20, 10}}]}}, {
@@ -403,7 +385,7 @@ zr2Q9fsfeIn6El7BFbz+v/8LvN4eZQ==
                     Directive[
                     Opacity[0.3], 
                     GrayLevel[0]]], 
-                    PointSize[0.1], 
+                    PointSize[0.125], 
                     AbsoluteThickness[1.6], 
                     RGBColor[0.663226, 0.6872815, 0.9117649999999999]], {}}}, 
                     AspectRatio -> Full, ImageSize -> {20, 10}, 
@@ -415,7 +397,7 @@ zr2Q9fsfeIn6El7BFbz+v/8LvN4eZQ==
                     Directive[
                     Opacity[0.3], 
                     GrayLevel[0]]], 
-                    PointSize[0.1], 
+                    PointSize[0.125], 
                     AbsoluteThickness[1.6], 
                     RGBColor[0.941176, 0.906538, 0.834043]], {
                     LineBox[{{0, 10}, {20, 10}}]}}, {
@@ -424,38 +406,38 @@ zr2Q9fsfeIn6El7BFbz+v/8LvN4eZQ==
                     Directive[
                     Opacity[0.3], 
                     GrayLevel[0]]], 
-                    PointSize[0.1], 
+                    PointSize[0.125], 
                     AbsoluteThickness[1.6], 
                     RGBColor[0.941176, 0.906538, 0.834043]], {}}}, 
                     AspectRatio -> Full, ImageSize -> {20, 10}, 
                     PlotRangePadding -> None, ImagePadding -> Automatic, 
                     BaselinePosition -> (Scaled[0.1] -> Baseline)], #3}}, 
-                   GridBoxAlignment -> {
+                    GridBoxAlignment -> {
                     "Columns" -> {Center, Left}, "Rows" -> {{Baseline}}}, 
-                   AutoDelete -> False, 
-                   GridBoxDividers -> {
+                    AutoDelete -> False, 
+                    GridBoxDividers -> {
                     "Columns" -> {{False}}, "Rows" -> {{False}}}, 
-                   GridBoxItemSize -> {
+                    GridBoxItemSize -> {
                     "Columns" -> {{All}}, "Rows" -> {{All}}}, 
-                   GridBoxSpacings -> {
+                    GridBoxSpacings -> {
                     "Columns" -> {{0.5}}, "Rows" -> {{0.8}}}], "Grid"]}}, 
-               GridBoxAlignment -> {"Columns" -> {{Left}}, "Rows" -> {{Top}}},
-                AutoDelete -> False, 
-               GridBoxItemSize -> {
-                "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
-               GridBoxSpacings -> {"Columns" -> {{1}}, "Rows" -> {{0}}}], 
-              "Grid"], Alignment -> Left, AppearanceElements -> None, 
-             ImageMargins -> {{5, 5}, {5, 5}}, ImageSizeAction -> 
-             "ResizeToFit"], LineIndent -> 0, StripOnInput -> False], {
-           FontFamily -> "Arial"}, Background -> Automatic, StripOnInput -> 
-           False], TraditionalForm]& ), 
-        InterpretationFunction :> (RowBox[{"LineLegend", "[", 
-           RowBox[{
-             RowBox[{"{", 
-               RowBox[{
-                 RowBox[{"Directive", "[", 
-                   RowBox[{
-                    RowBox[{"PointSize", "[", "0.005555555555555556`", "]"}], 
+                 GridBoxAlignment -> {
+                  "Columns" -> {{Left}}, "Rows" -> {{Top}}}, AutoDelete -> 
+                 False, GridBoxItemSize -> {
+                  "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                 GridBoxSpacings -> {"Columns" -> {{1}}, "Rows" -> {{0}}}], 
+                "Grid"], Alignment -> Left, AppearanceElements -> None, 
+               ImageMargins -> {{5, 5}, {5, 5}}, ImageSizeAction -> 
+               "ResizeToFit"], LineIndent -> 0, StripOnInput -> False], {
+             FontFamily -> "Arial"}, Background -> Automatic, StripOnInput -> 
+             False], TraditionalForm]& ), 
+          InterpretationFunction :> (RowBox[{"LineLegend", "[", 
+             RowBox[{
+               RowBox[{"{", 
+                 RowBox[{
+                   RowBox[{"Directive", "[", 
+                    RowBox[{
+                    RowBox[{"PointSize", "[", "0.006944444444444445`", "]"}], 
                     ",", 
                     RowBox[{"AbsoluteThickness", "[", "1.6`", "]"}], ",", 
                     InterpretationBox[
@@ -472,8 +454,7 @@ zr2Q9fsfeIn6El7BFbz+v/8LvN4eZQ==
                     RGBColor[
                     0.19561066666666668`, 0.0382696, 0.35294133333333333`], 
                     FrameTicks -> None, PlotRangePadding -> None, ImageSize -> 
-                    Dynamic[{
-                    Automatic, 1.35 CurrentValue["FontCapHeight"]/
+                    Dynamic[{Automatic, 1.35 CurrentValue["FontCapHeight"]/
                     AbsoluteCurrentValue[Magnification]}]], 
                     "RGBColor[0.293416, 0.0574044, 0.529412]"], Appearance -> 
                     None, BaseStyle -> {}, BaselinePosition -> Baseline, 
@@ -497,9 +478,9 @@ zr2Q9fsfeIn6El7BFbz+v/8LvN4eZQ==
                     Automatic, Method -> "Preemptive"], 
                     RGBColor[0.293416, 0.0574044, 0.529412], Editable -> 
                     False, Selectable -> False]}], "]"}], ",", 
-                 RowBox[{"Directive", "[", 
-                   RowBox[{
-                    RowBox[{"PointSize", "[", "0.005555555555555556`", "]"}], 
+                   RowBox[{"Directive", "[", 
+                    RowBox[{
+                    RowBox[{"PointSize", "[", "0.006944444444444445`", "]"}], 
                     ",", 
                     RowBox[{"AbsoluteThickness", "[", "1.6`", "]"}], ",", 
                     InterpretationBox[
@@ -517,8 +498,7 @@ zr2Q9fsfeIn6El7BFbz+v/8LvN4eZQ==
                     0.4421506666666667, 0.45818766666666666`, 
                     0.6078433333333333], FrameTicks -> None, PlotRangePadding -> 
                     None, ImageSize -> 
-                    Dynamic[{
-                    Automatic, 1.35 CurrentValue["FontCapHeight"]/
+                    Dynamic[{Automatic, 1.35 CurrentValue["FontCapHeight"]/
                     AbsoluteCurrentValue[Magnification]}]], 
                     "RGBColor[0.663226, 0.6872815, 0.9117649999999999]"], 
                     Appearance -> None, BaseStyle -> {}, BaselinePosition -> 
@@ -542,9 +522,9 @@ zr2Q9fsfeIn6El7BFbz+v/8LvN4eZQ==
                     Automatic, Method -> "Preemptive"], 
                     RGBColor[0.663226, 0.6872815, 0.9117649999999999], 
                     Editable -> False, Selectable -> False]}], "]"}], ",", 
-                 RowBox[{"Directive", "[", 
-                   RowBox[{
-                    RowBox[{"PointSize", "[", "0.005555555555555556`", "]"}], 
+                   RowBox[{"Directive", "[", 
+                    RowBox[{
+                    RowBox[{"PointSize", "[", "0.006944444444444445`", "]"}], 
                     ",", 
                     RowBox[{"AbsoluteThickness", "[", "1.6`", "]"}], ",", 
                     InterpretationBox[
@@ -562,8 +542,7 @@ zr2Q9fsfeIn6El7BFbz+v/8LvN4eZQ==
                     0.6274506666666667, 0.6043586666666667, 
                     0.5560286666666667], FrameTicks -> None, PlotRangePadding -> 
                     None, ImageSize -> 
-                    Dynamic[{
-                    Automatic, 1.35 CurrentValue["FontCapHeight"]/
+                    Dynamic[{Automatic, 1.35 CurrentValue["FontCapHeight"]/
                     AbsoluteCurrentValue[Magnification]}]], 
                     "RGBColor[0.941176, 0.906538, 0.834043]"], Appearance -> 
                     None, BaseStyle -> {}, BaselinePosition -> Baseline, 
@@ -587,554 +566,458 @@ zr2Q9fsfeIn6El7BFbz+v/8LvN4eZQ==
                     Automatic, Method -> "Preemptive"], 
                     RGBColor[0.941176, 0.906538, 0.834043], Editable -> False,
                      Selectable -> False]}], "]"}]}], "}"}], ",", 
-             RowBox[{"{", 
-               RowBox[{#, ",", #2, ",", #3}], "}"}], ",", 
-             RowBox[{"LegendMarkers", "\[Rule]", 
                RowBox[{"{", 
-                 RowBox[{
-                   RowBox[{"{", 
+                 RowBox[{#, ",", #2, ",", #3}], "}"}], ",", 
+               RowBox[{"LegendMarkers", "\[Rule]", 
+                 RowBox[{"{", 
+                   RowBox[{
+                    RowBox[{"{", 
                     RowBox[{"False", ",", "Automatic"}], "}"}], ",", 
-                   RowBox[{"{", 
+                    RowBox[{"{", 
                     RowBox[{"False", ",", "Automatic"}], "}"}], ",", 
-                   RowBox[{"{", 
+                    RowBox[{"{", 
                     RowBox[{"False", ",", "Automatic"}], "}"}]}], "}"}]}], 
-             ",", 
-             RowBox[{"Joined", "\[Rule]", 
-               RowBox[{"{", 
-                 RowBox[{"True", ",", "True", ",", "True"}], "}"}]}], ",", 
-             RowBox[{"LabelStyle", "\[Rule]", 
-               RowBox[{"{", "}"}]}], ",", 
-             RowBox[{"LegendLayout", "\[Rule]", "\"Column\""}]}], "]"}]& ), 
-        Editable -> True], TraditionalForm], TraditionalForm]},
-    "Legended",
-    DisplayFunction->(GridBox[{{
-        TagBox[
-         ItemBox[
-          PaneBox[
-           TagBox[#, "SkipImageSizeLevel"], Alignment -> {Center, Baseline}, 
-           BaselinePosition -> Baseline], DefaultBaseStyle -> "Labeled"], 
-         "SkipImageSizeLevel"], 
-        ItemBox[#2, DefaultBaseStyle -> "LabeledLabel"]}}, 
-      GridBoxAlignment -> {"Columns" -> {{Center}}, "Rows" -> {{Center}}}, 
-      AutoDelete -> False, GridBoxItemSize -> Automatic, 
-      BaselinePosition -> {1, 1}]& ),
-    Editable->True,
-    InterpretationFunction->(RowBox[{"Legended", "[", 
-       RowBox[{#, ",", 
-         RowBox[{"Placed", "[", 
-           RowBox[{#2, ",", "After"}], "]"}]}], "]"}]& )], ",", 
-   TemplateBox[{GraphicsBox[{{}, {{{}, {}, {
-          Hue[0.67, 0.6, 0.6], 
-          Directive[
-           PointSize[0.002777777777777778], 
-           AbsoluteThickness[1.6], 
-           RGBColor[0.293416, 0.0574044, 0.529412]], 
-          LineBox[CompressedData["
-1:eJxd2zmQM0cVwPEuSBQqINiAYFBRlIpyUeIWpwdsQNzCgBGXGT74QFz2YMDI
-NobhFphD4YYTKlS44YQbTrjhZGw4oUKK0vsv1f9Nun5+r1+/7tE5+vyWRy88
-8/gNKaX/vDGl/42Xv/HJy/hEGf8hxvfGOCnz+DTGWYxvivFtMV7F+I4Y3xzj
-W2Ms9N9nGslzXTzXOm9X/AnF6YN9LLSPd2r+u+R3q7/3aB+cE+u9L0b2936t
-t1T+B1T/g6r/IfXzYdX7iPI/GiPn9GSMnEuZr9fI6WN5vQazn4/HGNelwfT3
-lOo/leenp/N6zdN5fvqE1sfM/2SMsb9GTp9SfUz9lepjzufTMcbjsMHs/zMx
-xn4bTP3Pqj/M9fmc1sec3+fVP+Z6fyFfr8H0/8UY43nRyGmd1y8x9XCcd4fp
-/0u5S0y/OPbfYfp7Jq9fyg2Ofjs5fVnzMf3j6KfDnO9X8vwSc144rn+Hed34
-ah4vMevjuF4d5vH7bL5eieN8mmfz/A7z+P5ajPG6VmIer5j9Y85vk69XYh6v
-cienr+f1S0z/mPNTfvpGXq/EXH88i/ly+maMcT1LzHwc59Nh3le+leeXOOo3
-ineY/r8dY7xPlpjnM2b/iqfn8v7K5/J4g2N/neLpO7lLzPXD8f7S4VmMVd5f
-UeXxUvEK0x+O/beKdzjWHxRP381dYB5PcqX8RvEWR/8djv4H5adHWv9Rnl/K
-lfIbHOu1mOc7Zv+Y9b8XYzy+Chz1SrnCrK/5rfI7HOsNmM8b38/7LeQSc/44
-5jdyi3m843i9GRRPj/N+C7l8nOdXmOc3jvNoMa9Xyh+Un34QYzx+C8zrCY7z
-qHB8fmwwjz/M41/1Bjn9MJ9f4DjPEsf5VZjrj6Neizl/HOcxKJ62ebzY5vES
-R/0Ks3/FW8U7HOc3YM7/RzGyfzyL9THrY/aPefxh1sdxfQflpx/n/RWY6y9X
-ciO3cod5/mG+f/wk76+Qywdf/irM+jjqtXKn/EH1009jjO99BebxJ1c4zquR
-W8z6mPNXPP0sd4GjnxLH/OrBl79GblWv0/xBTs9r/efzeClXOPprNL9VvNP8
-QfH0Qt5/8UIeLxWvFG8e4rG+4p3ig+qlOs+f1nm8UHyheCmv5Uqu5UY+yK18
-kju5lwd5lNPPc0/lQl7IpbyWK7mWG/nw4MvY4jj/k/I7uZcHzR8VTy/m601f
-zOOFvMA8PuU1judDpfm18hv5ILfySe7Ufy8Pyh/VT/pFHp/KBY56iwfHf1V8
-rfmVXMuN5h8wryfySe40v8e83is+an76Ze4p5v0Q8/yXS3mtehWO9WvFGxzv
-Lwet3yr/JHfK7xUf5FH9pF/lnmKuP476Cxz1Shz9rxWvVL+WG6130PwWx/U8
-yR2Ozxc9js9HA55dxlH100v5/CmO/RQv5fkLzOcjHJ+v16pXqV6teKP4QW5x
-7OekeKf+esznTXlU/+nXeT9TzP4VX2C+b+Oov9b8Csfn6Vr1Ghz9HFSvxbPL
-eFK8Uz+96g+qP2p+2uXxKeb7sLzAPP4VX+Pot8LRT425P6H5B8z+5ZPcqX4v
-DzjOf8Tc/3o5xnj8Tl/O8wsc13OBuT8hr/HsMlaqV2u9Rj7guH/W4vgd4qT1
-Os3vMd+3lT+qn/RK3u/0lTxeYK4/5n4ljuu5xvE7SqV4rfUa+YDZv3xSvU79
-9Jjv+9rPqPnp1Rjj+k5fzfMLHP0tMPvHcf9ujWP9SvVrzPNf9Q+a38onzP0F
-HPvp5UH9jlov/Sb3FMf1K3DMX2DuD+C4PmvFK8VrzONf6x9wnGereifld8rv
-1e+Aef3T/PRanj99LY8XmNd/zP1qHP2tMddf8Rpz/0z5B9VvMY9/zP1sHL9H
-9Ko3aL0R8/r/23x/Uzy7jAWOegvM+x+O81srXmGe/6rf4OjnoHiLuf7qp8Ox
-v17rD4qPiqff5Z7iWL/Asf5C+SXm84/yK+XXcoPZP+bzD47rc9J6ndbrFR+0
-n1HrpybGeD+fYF4Pmzz/SvkFjv7myl8ovlT9Esf+V4qvcexvg7kfh2O/W82v
-8ewy7tRfo/he9Q7Kv5Zb7e+o/k6K3yjeybfqp5fvlD+o/r3yR/ms806/z/cz
-wXwexFH/CnO/Esf3lznm+5LqLRUvcVyvlbyWN+qnkrfaT635Ozy7jI3y9+r3
-oPi14q18lE86r5sHX/46HM+nW7lX/3fyoPO8V3xUP2c5/SHGuH4TzPdhHPWv
-FC9w9DuXF/IS8/1RXmm9tfrbqF4lbzW/Vr875TeK77XeQfWuFW9V7yif5But
-1yl+i+M8eq1/p/mD5t8rPspn1Ut/zOMTeYpjv1cP8ctfofhc8xfyUvml4ivF
-1/JGrjR/q3gt7+RG8/fyQfnXirc6j6N80vwbxTv5Vvm94nfyIN9r/iif5fSn
-fP5EnspXciHP5YW8lEt5Ja/ljVzJW7mWd5jrr/hePsjXcqt6R8VP8o3yO8Vv
-Fe/lO3nAPP8VH1X/LKc/5/kTeYqj/pVcyHPNXyi+xLz/Y57/yl8rfyNX8lbr
-1/JO9RvF95j3f9W/Vr+tfFT9k+rfqF6n+K3q9cq/U3+DfK/1R8XPqp/+kq8/
-wbHeVL6SC3kuLzDXX/FS8RXm9xQcn+82mPurqrfFs8tYa/4O8/u56u1V7/DQ
-z+XvWv228lH9nxS/Uf0Ox+fLW8V7zb9TfNB+7uVR9c+Kp7/m8QmeXcYpjvO5
-wvx7DRzf7+eqt1C9pVzKK9Vf4+h3o/wKx/2Hrfqplb9Tf432t1f8IF8rv1X8
-qPVOOL6/3mh/nfZ3q3o95vorPqife8zvHco/q7+0z/Mn8hTz/R/HeRc46s0x
-94twXI+l6pXyCnP9Md//VL/CcX9sq3q11t/huH/WKL6XD6p/rfVbHPdLj5j7
-VfKN+usw11/773W+d+pvUH/36mfU9Tqrn/S3vJ8J5v4P5vu/XGj+HEe/Cxzr
-LTH3z3HsZ4W5n6b5G9Wv5K3ya623U/1G8/c4Hh8H9Xet/bfyUedx0nneqL9O
-828V73H8fyd32s+g/u5xPB5GHPeHz8pPf49xdhknONafYp7/coHj96k5jvUW
-OM5zibn/h+N6rDDPf8z3P/VbKX+rejXm+suN9rvX/APm85/Wb1XvqPkn5d/o
-/Dqtf6v99Kp/p/xB532v+qPqnVUvvZ7nTzC/h76e519hfh/Dsb+55i+Uv8T8
-e3fVX6neWv1tVK9SfIv5vVnxndZrlL/H/HsEHK/P14q36ueo+ietf6P9dYrf
-qp9e+XeqPyh+r/mj4mddn/SPPD7BvP9jXv9xnEeB4zzmii8wn/+VX2q9lbyW
-N6pXqb+t4jXm/p/WbzR/r/M4KP9a+a3iR/mEuf7qp1P8VufXq5871R+Uf6/z
-GpV/Vv/pn3l8gvn3YDjqX2G+/+H4myu+0Pyl4qXWWyl/LW+UX6n/rerX8k71
-Gnmv/IN8rfxW6x8x7//Kv1G9TvFb7a9X/p3iw8P5X8Z75Y/yWfPTv/L4BMff
-FHP/F3P/B0f/c8zv5cpfPtS/jKXqr5S/Vv5G+ZW8lWvV26leI++Vf1C9a7nV
-eR3lk/JvtF6n+K3m9/KdPMj3qjfKZzn9O/cEc///wZe/K7mQ5/JCXv7f/wUv
-5wsR
-           "]]}, {
-          Hue[0.9060679774997897, 0.6, 0.6], 
-          Directive[
-           PointSize[0.002777777777777778], 
-           AbsoluteThickness[1.6], 
-           RGBColor[0.4286185, 0.2924847, 0.7194555]], 
-          LineBox[CompressedData["
-1:eJxd2zmw81YVwHENNC5dULyCQrxhGA/DMGY3u9gfW1BYzRJQIAGzJSZsDmER
-ARKzu3Sp8pUqXap0qdKlOlyqdMkwPn8z9+9G+X3n3HPuvVq8fF/e8N3nv/js
-a7Is+89rs+x/x+tr/HD8R5Ee8zhO4vimOE7jeB/H1+nP7+TXK4+6vKhD3zcq
-331nyn+z+rxF83ir6s3jyLrepvpvV/13yO9UvXep37tV7z3yQvnvVfx9mt/7
-lf8B5X9Q8/tQHNnnD8tFHGOfa0z9j6T9a0z9j6b9a8x+fCytV2PW83H1x9T/
-hOpj5vdJ1cf3cfyU6mP6P8Qx9qPG9P90HON6qjH1P6M45j76bNqvxsz/c5o/
-pv7nNR5z/p5Q/ycU/0Ic4z6pMfdFGce4rwrMfOQOc389GcfY3+LJNF7juB46
-zPq/mMYLucYxvw4z/kvqj+P81Zj+mPl/Oa1XYMbjuP46zPXzFY3H9zEex/no
-MP2/qvFyjWN9Heb8fk3jMf2/luZ3ys+WGo+53jD7h+n/9XQ9xdfT/Bqzf5j+
-30jjBaY/jvqdnH1T4zHjMfPHjP+W5o/Zf8z8lZ89FcfYj+KpNL+WO8zz8dtx
-jOutwNw/mPOH2b/vxDHWW2D2H7N/mPFVHON5lVdpvMDRv8L3UR/H/dlg9hvH
-+gfVz55O8/On03iBY3yl/BrH+hsc6+lUb8Ccv++m9XPM80iu5BrfR3/MfuN4
-/g6Y++d7ab1cLnBcHxXm+lB+g2M/Osz6Fc+eSeeTY67HZ9L8CtNf8UbuMP0x
-1/+zaX6O6Y85/5j+ym/kTuMHzPX3/TSe47h+Csz+Y54vGt/IncYPmPX/QP3l
-ArP/itdyg7n/FB8w61+pP+Z5uErzK8z6Mft/8/XVyYOc/TAdn2P2H7N+udb4
-Ru5Ub5CzH6X1crnAXH84xteKNxrfyYPysx+n881vjj9VvML0V7xRvFN8UDz7
-ifrfHH+qeKV4rXgjd5j9Vzz7aRrP5UKuMP3lRu40fpCz59L55M+l8UKulF8r
-3sjdLf/6GuTs+TQ/lwu5kmscr0bu5EHO1qmnmPkoPle8ULyUK3mt8bW8U34j
-t3In9/Igj3L2s9RTOZfnciGXciWv5VreyY3cYq4vxXt5kEeNz15I49Obr8f8
-hTR/rvxCLuVK9daK16q/kxvlt3In9/Igj3L289RTzPWv+FzxQvFS8UrxtVzj
-eH/YYd5PbvnXY6vxnfr1ig+qPyqe/SIdP8V8HsDxeWKueIGjfilXmPMv1/JO
-4xscn0da9e80v171Bq1vvMXj9cs0f4r5PIC5/pVf4JhPKVc45reWa/XbqV+j
-fq3cyb3GD5rPKGe/SvOnmPXLc7nQ+BLzfQlHv7VcyzvVazDrlzv16xUf5FH9
-sl+nnso5Zv1ygePzcanxFeb6V36t+E7jG8Vb9e/kXh5w7M+o+tkm9RTz/MNx
-/83lQvml6lXKX2M+vyt/p3gjt3KHYz971RvUf8R8/3ox9fTFND9XfI65/5Vf
-Ytav/LXiNY7v3zv1a+RW/TqN7zHft5U/ytlv0vypnGPWj/m9S/ES831B9da3
-+PVVY86/3Gh8q36d3OP4vXTQfEfVz16KY/x+NX0pzc9x9J9jfm9WvNT4CvP8
-w/x+ofyd4g3m+le8U/1e8xkw97+c/TYdP8U8/zHrlwuNL3HsZ4VjfWscf09X
-q99ObuRW9Toc+9HjWN+A43yNqpf9LvVUznGMnyteYM4/jvlUiq81vsZc/xrf
-aHyLWb/ye3x/PQ6a/6h62e/jyOcfzPWPuf/lAvP8wzz/5LVc45jPDvP+r/qt
-3Mk95v0P31+Po9ab/SGO3P+Y9WPe/xUvMNe/6lU4+q8x7/+qt8M8/1W/lTvN
-r9f4Qf1GxbM6rTeRpzj2907OcdSfafxc+Qu50PgHucSxvqVcqd9K49fK3yi/
-Vv4Wx/7sNH6P76/HRvUeVa+VD6rXyUfl9ziu1xPm/U3zPWO+7yh+kbM/pv0n
-8lS+w/w+gKPeTPlzHPuzULzAMd8H1S9Vf6n8SvVXGr9Wv43G14pvMfej+u9V
-v1G9R82nVf2D4p3qH2/1r69e/U7yoPpn1R81v4vGZy+n4yfy9OU0/+7m6yvH
-0W+m/Lm8wPx+Ij8ov9R8lupfqf9K49eqv5Fr1d9q/E75e8UbjX9UvNV8D3Kn
-/KP69co/KT4oflZ81Pwu6pf9KY1P5Kl8h7n/cfSb3eLX11xeyIX8oHql4ku5
-klcav1Z8o3it+FbeKX+v9TeKP2p8Kx+U3yl+lHvlnxQf5LM8yhc5+3PqiTyV
-7+RcnslzeSEX8oNcyku5klfyWt7INY793Sq+k/dyIz/efD22ih/kTv2Pci+f
-5EE+q/4oX+TsL6kn8lS+w/w+JM9u+dfjXPGF4gWO58uD8kt5KVfySvXWim+0
-nlreyjvNd6/6jfIf1a+VD6rX4Xj/Oireq99J9QbFz6o3qt5F+dkr6fwnr6T5
-U8XvMOdf8Rnm87/qLRQv5Ae5lJeYz/84Pj+tlL9WfKPxtfK38k7ea3yj+o/K
-b5V/0H502r+j3Gv8Sfs/qN9ZHuWLnL0ax/i+MZGnr6b5d3KOYz0zzO/Fyl9g
-fj/AfP7T+FL5S8z5V/4K83uT4hvVqzW/7W0919dO/fZyIz/KrXxQ/079j9qP
-XvGTPGh9Z52/UefnovHZNo1PMOcfx3zv5Fz5M8z3P8UX+P56LHCcrwfVLzH3
-P+b5r34rzN83aH0b1a+Vv1W/nfL3cqP1PeL499Wt1nfA/Hte7cdR9Xr1O8mD
-1n9Wv1H1LnL217T/5K9pfIqj3p3yc8VnmOc/5vcfzP2Pef+XS41fql+F4/e2
-lcav1W8j15rvVvGd4nvNp5EftT+t5ntQvFP9o/r3qn+SB9U/Kz4qfpGzv6X9
-Jpj3fxzXw52c49j/GY7/j2aOZ9fjAvP7H+b9X/kljvtpqf4Vvr8eV6q/Vv2N
-4jWO/diq3k7eY57/2r9H1W9x3O8HxTv5qPn0qn/S+Rm0H2f1GzX+ovlnf0/7
-TXDMZ4p5/mPe/5U/U/5c+QvlF/KDxpc41reUK3mlemutb4P5/KfxW813J+/l
-BvP9X/Vb5R80v04+av296p0w51/1z6o3avxF+dk/4sjnP8z5x5x/Ocf8/ifP
-MZ//Mb//qf+D6pfyEvP5T/VWqrfW+I3G15rfVuN3Gr+/5V9fjeo9ql6r+EH7
-06n+Ufm96p2UP8hn1R9V76J49s84xvmeYP49EOb3P8z9L8+UP5cXmO//8sPN
-11ep+BLz74tUf6X5rzV+o/xa8a3q71RvLzfyo+q16ndQvJOPqtfLJ9UbNP6s
-+ChfVC/7V+qJPMWcfznHfP/T+LnyF3Kh/Ae5vNW/vpaKV+q/ktfK3yheK76V
-d5rvXvNp5EeNbxU/yJ181PhePsmDxp/lUb7I2b9TT+TpzdfjneK5PJPn8uL/
-/i+ugPv2
-           "]]}, {
-          Hue[0.1421359549995791, 0.6, 0.6], 
-          Directive[
-           PointSize[0.002777777777777778], 
-           AbsoluteThickness[1.6], 
-           RGBColor[0.563821, 0.527565, 0.909499]], 
-          LineBox[CompressedData["
-1:eJxd2zmw61YZwHENNC5VULigEB4m42EYxuxmjdiC2U3YzC4ehJgE8sxuAgGF
-BDBLgkuXKl26dKnSpUuX6nCp0iXD+Ptf5vxvc+b3vu98Z5Fsy+fe95ZHj59+
-5g1Zlv3njVn2v/b+0z+ZtlmZehB+c7R5tE9E+6Zoi2iHyqcdKe9t+nf6vVX9
-ntC/j9W6zttV7x2qM1H9d2pe79J471b8PdGy7vdq/Pcp//0abyp/IFr29YOq
-9yHV+7DiH9F8P6r6Tyq/jDb2o8bs58eijX2tMev9eLRxX9SY+X0idY25Hp9M
-XWOu46fS+dSY6/aU4k8p/ulo4z6o5WyWjldj7oPPKI7Z389GO4o45v76XLSs
-D3M9Ph8t+4OjXvYFxTH1v5i6xtT/ksbHXN95tLFfJY711/M0v8Vcny+n8RIz
-Ho71tJj74+lo43VWYq4XjvW1mOv7lTS/xPG6rDH9Mdfvq+qPud445tti9u9r
-ab0SM38c9VrM/f/1tH4p15j9x+z/N1KXmPsBx/62eBTtQv0x42P2D7P+b6b1
-Ssz6cVyvFnP/fit1iaNeLbeY8b+t+eO4HrXcytl31B/HfGvFW8z9+910fiXm
-/Uhu5ex70XL/4ficqjHzx1z/76fxEjM+jnqt8rMqHb+QSxz1KrnGcf0axVsc
-8+3k7AcaH7MeHO9nFeb9RfFGbuUOs/+PNP6jNF7imE+FGR/H53Wj/FbuMPf/
-D1MXmPcDPIrx5RrH53GD4/O4xTG/Tv2zH6UuMOPjqF9hPu8Vb3A8N7aY8TGf
-T89ofBz7Wype4RivxrG/Deb6q16nePbjaGO9hVzi6F8pXiveYMZXvMM8Rz+b
-ung2zS/lCrN+zPqV32Lufzlbpi4w78d4FONj1o9ZP475tYp3mPX/JHWBo38p
-V3KNef0r3mLuP42XPRdtfL8pnkvjpVzJNY77vcGML3fqnz2fzq94Po2XOOZX
-ybX6N5jxVa9TPPtpGi/kEsf6KsVrHPNplN8qv5Ozn6XzKeQSx/oqzPrlRm7l
-DvO99oU0XryQxkvFK8VrxRu5VX6HWf/jNF7I5eM0v1K8lhvM+A/x+0+neLZK
-++dyIU9w9C8Vnz/4/lPJK7lWva3ijXyQW/ksd3IvZz9PncuFPJFLeS5X8kqu
-5a3c4Nifg+KtfJY7uZezX6T1c7mQJ3Ipz+VKXmHeP3D8bJXfPMTv7UFulX+W
-O43XK579Mh0/lwvM+uXyIf/ezhWvVG8l1/JWblT/gHm+U/yM+bxTvMe8//8q
-rZdjPo8Un2Den5Q/V7xSfIV5fpa36t/IB9Vr5bPm2+FYb6/87Ndpfi4XOPpP
-cPQv5bn6V/IK8/6t+Fb1GsUPirea31n5ncbrlZ/9JtrY/1wu5Anm8xmzfsUr
-HM+LK7nG8fy6lRv5gEf3tlX8LHfK7zHPv79NnWO+D8gTuVT/OeZ5XfkrzPmE
-4lvM/a/6B8zznXyWO9XvNX62Tuebr9P8QvEJjvmUyp8rXuEYb4U5n8Kje7tV
-fqP6B7nFvP4V7xTvNb/sd6lzzPMojvlNlF/i2J855rwAx3nCCrN+1d+qfoNZ
-v/Jb+azxO/XvVT97MdpYb/5iml/g2L8JjvFKeY65/jjWu1J+rfG2ciMfMOdL
-8ln1OxzneT3m90C/T+eX4zifKnCcD00w50M46s3lSl7JtcbfYtaP4/46YM4X
-8OjenjW/Tuvp5ewP6fg5jnqF4hPM+jHrlysc+7fCnK/iOJ/eYtYvHzDnG4qf
-Nd9O7jW/7KV0fvlLaX4hT+QSx37MMe//mPc/zO8XMPc/Ht3bRv0Pirc47oez
-8ju51/yzP6b1cszzD476E+WXmPd/zPoxr3/M+TGO/d8q3mi8g/JbzOe/+nea
-Ty9nf0rnn+PoX2Be/5jfF+BY31yuVG+leI15/sGje9soflC8Vf2z1tMpv1e9
-rE7jAznH8fkwxHw+4Lg/xpjXi/Knql+q/kz15spfyJXyl/IKx3rX6l9rfhv1
-32o9O+U3iu9V/4DjfjtqPq3yT5jnGY130fw6+ar8XvGb4tnL6fiDl9N4jqP/
-UC5wXL8x5nlRnqp+Kc8w3ydwvB8tVK9S/lLxleqvNf9a+Rt5q/o7zPMpjtff
-HvN9Vftz1H63ip8UP2v9F7nT/K4av1f9m/pnf049wFEvx1FvKBcPvv+M1X+C
-uf6Y52fFZ5rPXF7IleazxLHeleazVv9a8Y28Vf5O9RuNv1f/A+b1r3qt+p9U
-/6z8i+Kd+l9xnD/1it/k7JW0/uCVNJ7LQ7lQ/7HiE3kql/IMc54oL+Tqof/9
-Zymv5LVcq95G3ip/Jzda/17xg3yUW/kkn+WL5tfJV7lX/5ucvZrmD+T81TR/
-KBfyWJ7IU9Uv5Zk8V/+FXMlLeSWv5VreyFt5JzfyXj7IR7mVT1r/+SF+by+K
-dzjuvyvmvFP9b+qf/SX1AMdPLg+VXyg+lifyVP1LefaQf2/nON5PF3Kl/KXG
-Wym+lmt5o/5bzW+n/Abz+pcPyj+qfqv6J/U/yxfM85/244q5/sq/YZ7//hpt
-fD4NMOfhmOd/zPXHsb6x4hP1n6p+Kc8wz3+KL1SvUv5S8ZXia623Vv4Gj+7t
-Fsf+7dS/kffyQfWPmPNL+aTxzlr/RfU7re8q98q/aT7Z31IPMM//eHRvh5jz
-EcXHmOc/HOuZKr/E8Tw90/hzeYF5/tf8l6q/Uv015vxB3ih/q/F3Wn+j8faq
-d8BxXnBU/1bjnRQ/4zh/uKhep/gVx9+p94rftJ5sk9YbYM7DcVzPIeZ8XPlj
-HOuZYJ7/5VLjz3D8/fFc8QUe3dsKx34t5ZX6r9W/1vw3mPM45e+0vkbeY64/
-jv0/Kt7iOA89ab5n5V80v07zuyq/V/5N+5P9PR1/gOM8Nscx/yGO9RaY7/+Y
-7/+KT9W/VP2ZPFf+AnO+pvwl5rwdx36sMb9/xFx/zO9jtZ4dHt3bRvX28kH5
-R62n1XxPip/V/6L1d1r/Vevt1f+m+tk/0noDzPs/jvUPFS/Uf4zjfprg+H8w
-Uxz/D6bE8f9cZjjuvzmOv+df4Hh/qHCsZ4lH93al/DXm/F3z38hb1dthfj+H
-4/1xr/06aH5H1W9V/4T5/i9fVK/TeFddn17rvWF+//HPND7A/D4Ix/yGihc4
-rvdY+RPM5z/m9a96M9Wb47ifFzjWV2E+/zHnfxp/jfn/CZrvRvux1fg71W/k
-vcY7aL5H5beKn+Sz9uuieKd6V8V7zf+m+WX/SvsP5Bzz/I+5/jj2a4xjvIn6
-TzF/P6PxZpjnP8UX6l9hzv/llfqvMed/8kbe4tG93Wl+jfL3mPNfHN+Hjoq3
-6n/CvP9r/y7K77QfV623V/ym+WevpfmD19J4jnn+wzz/yWPlTxSfKl4qPlN8
-rvgCc/6r+S81/xXm9a96teptNP5W/XeKN+q/lw/yUW7lk+Z3xpz/yJ18lXv5
-pvGy16Pl/Of1NJ7LQ7nAXH95ovwp5vpjXv+Kz9V/gWM9lea/VHylemvVq+WN
-6m0f6t1/dqrfyHv5oHpH1Wvlk3yWL3InX+Ve49/k7N9p/kDO5eGD720hj+WJ
-+k//7/8C0yMAWw==
-           "]]}, {
-          Hue[0.37820393249936934`, 0.6, 0.6], 
-          Directive[
-           PointSize[0.002777777777777778], 
-           AbsoluteThickness[1.6], 
-           RGBColor[0.663226, 0.6872815, 0.9117649999999999]], 
-          LineBox[CompressedData["
-1:eJxd2zuQ81YVwHENNC5dULigEDsM42EYRrzNM+K9vBIRAiwEghIILBASAQk4
-4RFBICwQiEuXKl26dKnSpcot1eFSpUuG8fkvc//b3Pl9595zz72SbEv2945n
-Xnj82bdkWfaft2bZ/9rL3/RI2mZl6lmZtnO1b5MX+ve3K54rfqX2nYq/S14q
-37s173uU772at9A871P8/cr/Ac3/QflD6v9h1fMR9V/JH1W9H1P849Gyj59Q
-/k+q/k/Jj6i+Mp2vxezHpxXHHIfPRBvHocXU89k0X4sZ/zmNx6zv86lbTP4v
-KI7Zry9GG+ttMefNtcZj9utL0cZ508rZl6ON867F7N9Xor2KOKb+r0Yb+9Fi
-6vua4pj8j6b52kfT/tljqv8xxato4zoocZzXLY7zuMes/+vRxvpLucVx3fSK
-Z4+n6ynlFsf6eszx+Ybmx5xPOPL1mPqfiPYqxj+R9m9x5Osx1883VT+O86+V
-exzzZd9K85dyi2O9PWb/vq36MfXLPeb8uknzlzjytTiuj179s+9EG6+zJeZ8
-xJGvx5x/3402jkeJ43W3VbzH1P9ktBz/J9P+LWZ+TP3fS+st5RYzP+Z95fup
-S8z+Y+bHzP9UtLEf5VNpvMWxHz3m+v9B6hJz/ijeY86fOp0vx3G+lnXav8a8
-Hql/h69iPhznz6h49nRaX/50Gi8VrzH7gyN/h3m9wHG9jsqfPZM6x+wnjv2s
-FW9x7E+n/j2OekbM+9sP0/pyzPw41lvLLY7zr9P4HrP/imc/ijZe/3PM9YRj
-fI15fcNXMT/m9UrxEXP9PhttnE855nqUa7mVO8z8ONYz4qgn+3HqHMfn3hLH
-emscn39bHMevk3v1HzHX/0/S+nO5xFFPjTn+mOtP8R5fxfyY6/82WvYfR/0l
-5vzDnP/q3ylfjzn/5eynqXMc51upeI3Zf7mTe+UblS/7WbSxfzmO8SVm/zHn
-n8Z36t8r36jx2c81v1zKNY78LWb/MetX/1Hx7Lk0nuO43yufS/vXmOsfM7/c
-a/woZ79I58sx1x+OfDVmfsU7zPqVb1Q8e17zP5/2LzHzK94q3sn9Q//L36jx
-2Qupc7mUa7nFUX8n9/IoZ03quZzj+CsULx/il7aSa/Vv5Fb9N3KHYz/3ivfK
-N8ijPGk92S9Tz+VcLuRSruRabuRW3sidvJd7eZBHeZKzX6Wey7lcyKVcyTXm
-+Mstjutxo3infHu5V/9B8VGeHhztr9PxcznH8VcoXipeYV4v1b956H9pW3mj
-/p3ie8z9JI7rY1A9ozwpf/ZiOn7+Yto/x7GeQi5x5KsUrxVvlL9VfIN5P1V9
-e+XvH/Jd2kHxUfknxbOX0vHzl9J4juP9upBLja80vsaxngbzvEneaHyHo/69
-5usVHzTfqHyT4tlvUs8x9yP46tIWmOOPYz8qja+Vv5FbeYO5n5P3mM+3ig+K
-j8o/KZ79No3PMcdf8ULxEsd6K/WvcexPg7n+Mccfx+fnDke9e8z9ncYP6j9q
-/kn1Z+t0/HydxnMc9RaY1z/M+uUas358dWlbxTeY6x+zftXb49ivQeNHHPeb
-k+bLXk7rmePIn7+c9i8w9+caX8m13OC4325x1L/Bsd5O9ewV71XPoPgoT5ov
-eyXa2J/5K2n/HMf9YqH+JY58FeZ5gdyofytvNH+n8XvM+5/iA766tCOO/Zm0
-nux3qec4nqfkOJ7/FTi+JypxzFdhnhcpX4M5/uq/0Xyd6ttj1o85/qpnVL5J
-8ez3af45jnpyucC8/+HY/wrz+odjvgZz/JV/g1k/jvXtla/X+AFz/uN4fjop
-f/aHaOP4zHF8X5HjmL/APK+VK+Wrcexvg6P+Vvk3mPNf/feY55saP2Cedyg+
-ydkf0/5zzPMIucAcfxz1VTj2t8axngZz/DHHX+M7zPmvfL08aD2j6ps0f/Zq
-mn/+ato/x5G/wKwfx35WyldrfCO3yrdRvk717NW/x3z+1/hRnjCf/9poY79m
-OPLPcdS7kHN5iaPeQl7JJY7jca16KvW/UX21+t/i+PzSKL7WfK18h+P4bTR+
-q3o6HPu7w3H97xU/qP5e8aP2c1D8Hsf1MsonzOu91nNW/dmfoo3zZ4Y5/jjW
-v8AxPscx/1L9CxzrWWE+P6v/tVxp/A2Oz581jvP5Vvkbxddab6v4neIbrW+r
-+jrNt9P+7NX/IPfyUR5Uz73qHXW8TopP2r+z+md/Tueb4VjPHEe+hfrnmOtf
-8QLH/cNK+UrNd425n5RvNL7GsT+3+OrSNuq/1nyt6rtTfCNv5Q7H+bhTPXv1
-PyjeK36UB/le9Y6KnxSf5LOcvZbWP3stjc8VX2DuD9V/qf6FvJJL+foh3+Wv
-UvxG89fyrfo3qm+teCvfaf6NvFX/TvGd6tmr/0HuNf6oegf1v5dH+aR8k+Jn
-xbO/pJ7Jc3kh5/JSLuSVXMrXciXfYF7/5Vu50fi13Mp38kbeyp28k/eq56B4
-Lx/lQb5XvlHx04Mv7SSf5eyvqWfyHHP9y7n6LzHPi3G83q00vlT8Wq4e8l/+
-bpS/lm/lRvWtlb/FvP/LG/XfKn+n/DvF94of5F7rO2p/BsXv5VH1nTDP++Sz
-+mevRxvrnWG+D3k97b/AfF8pL9W/wLEfK8VL+VquVN8N5vO/8t9injcp31r9
-W/W/03o26r9Vvk79d4rvVe9B8/Xa76PWO+D4fHWv+UbVd1K+SfWcNT77W1rf
-DPM8XPEF5v4Px/3JEl9d2gLH/dBK8RJz/ydX8o3mr1XvreptMMcf8/wdc/wx
-zyOUf6t8nerZaf69fNB6eu3fUfMNGn+v+UfVf1L/ST6rf3aXzjfDV5d2jrn/
-x3z+l5fKVyjfCvP8XPFr5aswx1/ja/W/lRvlX2N+H6l8dzjO1436b+VO9e0w
-z6s0/0Hz9Rp/xHH/Pqiee61vVL6T4pPqOWu+7O9pfTMcx3uOY70LzO81FV/K
-BY75Vpjfd+Go71rxSuNvNH+t+m/Vv8HxvH2NYz9bjb+TNziun63yd9qvHY7z
-f6/5Durfaz1HrX+Q79V/lE/a/0k+a33ZP9L6Zjj2a47j+Cww3w9gXv8x35dp
-/ErzlfI1jv9HU2He/zVfrXpuNV+j/GvM8z/F7xTfyFu50/id6tmr/0H19Zjn
-P1rfoPH3Gj9qvhO+urST8p+1n9k/0/wzHOPnONa3wPH9V46jnqX6F/JKLnGs
-91rzVzjOxxsc/x+lVv23mNd/eY35/SaO/buTN1rfVvk6zb9TfK/1HOQex+vB
-UfUNyn8vj9q/kzwp/1nO3kjrnWG+D34j7b/APP/BfP5XvgLz+o/5fbni15qv
-wjz/wzz/wzz/U30Njv1Ya3yr8XeY3yNp/q36d8q3k/fyQfX1ih/lQft5r/io
-+EnxSfWeNX/2r3R9M8z7P+b9X/1zeYn5/Kf4Si7la42vcNR/g/l9Aeb+T+Mb
-jV9rfKv+d5j7P43fan86xXeqZy8fNF+v9R/Vf8B8/6P5Rvmk8ZN8xvz+799p
-fIa5/8OxHwv1z3HkW6p/ofhK+UvM9z/KX6n/Deb3RZrvVm7kteppNd+dvNH4
-reKd4rsHX/72ih80vtd6jooPynev+Kj8J61vUvwsZ2+m/Wfy/M20/wJz/B/i
-l7+lXCjf6v/+L6o5C3U=
-           "]]}, {
-          Hue[0.6142719099991583, 0.6, 0.6], 
-          Directive[
-           PointSize[0.002777777777777778], 
-           AbsoluteThickness[1.6], 
-           RGBColor[0.762631, 0.846998, 0.914031]], 
-          LineBox[CompressedData["
-1:eJxd2zuw61YVgGENNC5dULigEGcY5gzDMOZtnhEEEgcImBDAkAAiEGJCIA4Q
-YiCAeATMK7h0qdKlSpcqXap0qQ6XKl0yjNd/mP2fZs9319pb+yVZkn3f8dzL
-Tz3/lizL/vPWLPtfefsbHsnSvyL995E8LtJ/f1uR/vskyrervIsylylp751q
-511q517//m79+3vU7nt13KnqvU/136/2P6D8Dyr/Q8r/sPI/ovgsSsb5UcU/
-Jn9c/kSUjOuT8qeU/4j6W6THr+Ts01HGPFaY9j8TZYyvwhzv0fR41aNpfvbZ
-tL0KM8+fS11h1uUx1X8szc8ejzLWtXo8zc/mis8VfyJKxv+E4p+PMtaxkrMv
-KI7ZF19Mx1Nh9tGTqv+k4l+KMvZhJWdfjpLxYc6LRTqeAkf7FY592WL2yVdS
-Fzj2YYWjvRazPk9FGedh8VSaX+E4D1o5+2qUMd4Cs19wjL/FrN/TUcZ+LHD0
-p3o6zW8x8/u1tP0Cc3wc691izvOvRxnjLTDrKbeY+fuGjo/ZL5j5x8zfMu1P
-gakvt5j9+80oY/8WmPnDzB9m/30rdYGpjxk/ZvzPpP0rnknjFWb8mPV7Nkrm
-79k0v8IxvlbOvp26wPQfx3W/xZy/30n7W+BYnwozfuVn31V9zPUKM/+Yz70y
-7V+O2Y845qfEsf4Vjvmv1V6r9no5+17aXo5ZT7mUKxzt1ZjzHcf89ZjxP5fm
-58+l8QLHfJaY8Steyy2O+egx4/9+2l6OuR5jxo+5nuPYfzVmv+MYTy9nP4gy
-rn85Zj/j2F8lZvxyrfwWx3z0mOvv82l+Lhc41q9UvMKsP47xtfgujo+5P/lh
-6hwzfhzzU2LOL8VrzPHVfo+jP9kLUcb9aP5CGi9w3I+VOO5/K9WvVb+Ve9XP
-Vmk8x3weyiVm/DjGWyve4tivvZz9KMrYDznm80DxUvEKx/zWOOarxTG+HjP+
-F9P8/MU0v3gxzS9xPI9UmPnHMV+t6veY/ffjKOP+OMfRn0LxUq5w9KfGcbxW
-7jHPPy+lzl9K8wu5xPGcV+G7OD6O/rSq38vZT3R8HO0XOJ4HSxzPlxWO59Ra
-+a3a61U/+2nqXC5w1C/lSvm13OKYj17x7OW0vfzlNF4oXsoVZv3lVvm92s/W
-Ucb8jeUcx3xO5UL5C7lU/lrx6sG3v51cy43qt3In9zjeVwyKZ6+kHr+S5ufy
-9CE/askLuZTXciXv5Fpu5Fbu5F4e5OxnqcdyLk/lQl7IpbyWK3kn1w++lY3i
-rdwpv5cHOft5lLG+Yxx/ueJTuZAXql8++Fau5QrH+bHDcb7Wym/Ufqt4p/q9
-PMjZL6KM68FYznG0P5ULeaH6JY7r0Rpz/6L4DjN+xRvVbxXvFO/lQc5ejTI+
-f8Y42stfTfOn+O5WFvICc7+i9tfKr+Qd5n5GbpTfqr8djvnv5UHOfpn2b4xj
-vLk8xdwf4rgfW+C4HyyVv5YrHPO1w4xf+Y2O1yq/k3vVHzDvP19Ljz9+LY3n
-ONqbYu7P8N2tXGDulzDrr/qVjrfDPE/Kjeq36l+neK/+DepPtknzx5s0nuPo
-3xTzfIxZf+WXam+Noz+V8neY9cexPo3qt8rvNJ5eHpSf/Sr1GPM8jON5c4p5
-PpQXmPHLax2vwux/ucasv47X4nj+7XA8j/c4vicYMO+nf516LOeY8WOez3A8
-ny9w9K/EsV/Wildqb4cZP767lQ2O+WsV73CsX49j/gfM8+dvoozxjTHvw+Sp
-XOB4X7fAsR4ljvGu5Urt7VS/VvsN5n08jvnt1H6PY7yDnL0eJfsfx3rkr6f5
-Uxz7qcDR3wVm/RVfY96P4pj/HY79VOPYj43aaxXvMPtf/R/UfvbbKGP+xzjm
-N8fxvdtULpS/UHslZvxyhRk/5n2K3GDOf9Xv1H6PY7yD4tnv0vgYx37Lcczn
-VC4w6495X4zZ/3Il71S/Vv8azPs1ucO8b8RxPRkw3z/+Pq0/xrwPlqdygbn+
-qb1SXqt+hWP+dpjPf8z9j+ItjvF1mPsfecDc/1ZRxufjCMfxxvIEx3hyxe/l
-KY7+znD0p1B7c8x84ji/lpj30Tj2zwrH/K5xzM9G/akU36r/O7W/V/9q9f+g
-9hu1d9TxWsVPaq9T/Kz56xW/yIPau6r/2R+ijPkcyWPM+mM+H3C0f6/8KY7x
-zuQCx3jmqr/A8fm9VP1S+Svlr+WN6lfq/xbH/tnJex2vVv2D2m/ko/JbtXeS
-O3x3K8+ar175F413UP5V7WV/TOMjzPmPo72J4jmO+/t7HO1PcVxfZsov5Lnq
-LxRf6vil+r/CcX1bK3+j/Ereqr879Wev9mvFD4o3OObvqHir+icc4+3ks+r3
-OJ7/L2pvUP5V+dmfUo/ksTzB8b4ql+8x74vkmVzIc7W3kJc43reV8kr5a3kj
-V/JW3uF4X7LX8WrFDxpPo/aOqt/Kp4f6t79O8bPiveIXeVB/rnL259QjzPtQ
-xSdyrvz7h/jtbyrPlF/Ic3khL9VeKa/ktepvFK/krbyT93ItH+RGxz/KrfJP
-cief5V6+yIPW64r5feUbaf7ojTQ+licP+bcyx6y/8qfyTPULxeeKLxRfyiWO
-98UrzPsmHNfzjeIVjuvjVt6p/b3itXxQ/xrVP2K+H1T8pHin9s6K95qvizyo
-/hVz/f9L6hGO/ozlCeb3EpjPfxz9m6r9meKF2p/LC3kpl2p/pfbXONZnI1fy
-FnP/j2P/7JVfK37QfDTq31FulX+SO/ks91qPi/o3aD6uOn7219QjfHcrxzja
-m2C+r8asP+Z9MY7+zTD3/4rPFV/guF9eYn4PheN5ZYV5/sPxvLNRfqXjbzH3
-fzj2w17jq5V/0Pw1ih91vFbze9LxOvms+ejV3kXHH7S+V+Vn27R/o20aHys+
-wTz/45jve3mKef7DvD/GMZ9zeYFj/EvM78HU/grzvg3Hftlgfl+p/K36v5P3
-Gn+t+EHxRvEj5v2d+n/S/HTKP8s9jv18kQf5quNlf0s9wnH8Meb5H/N7PRzv
-Z+5xzPcUx/vQGeb9IY7xzBVfyEvM+zX1b6X21srfqD+V2t8qvsOxX/aY9z/y
-QcdvMOsvt8o/aT479e+s/vVav4vmY1D/rjpe9vcoY71HmOd/HNeDCeb3eqp/
-jzn/1d5M9QvM+qv+Asf/J1ji+P6hxDE/Kxz7b425/mPWX8ffKn+n9vfKr5V/
-wLF+DY7z5ajxtervSe11mq8z5vqv/Is8qD9XxbN/pO2NMOe/PFF+rvg95vtC
-eab6BY71mMsLzPUfx34sMeuP43xd41ivDeb/V8hb5e8w13/1r1b9g9xovEfF
-Wx3vpPwOx+fhWfPRyxf1d5CvmOv/P6Pk8x/f3coxjvoTHP3NMe9/cbQ/xZz/
-mPf/yp9jfk+Aef+r/FLxlY63xnF/utH4KvVnK+9w3D/tFa8xz3+KNzr+UfFW
-9U+KdxrfWePrFb9o/gbFr3L2r7R/I8zvQTD3/4rnmO9/cOyPKeb7H7lQe3PM
-/Z+8VH6p+Er9WcsbjadSe1v1b4djPfb47lbWav+geKP6R8zzH47ns5Pqdzie
-t86K91q/i+KDfFV+9mbanxHm/c+baf4ER3u56t/j6O9U8ZniBY7xz3Gsz0L1
-l3Kp/q1Uf638jfIrzPprfDvl7+Va7R80vkbzeZRbjf+keKf2zsrvFb8oPshX
-zPvff6ceyWN5gvl9NOb9vzyVZ/+v/1+7TBgq
-           "]]}, {
-          Hue[0.8503398874989481, 0.6, 0.6], 
-          Directive[
-           PointSize[0.002777777777777778], 
-           AbsoluteThickness[1.6], 
-           RGBColor[0.8519034999999999, 0.876768, 0.874037]], 
-          LineBox[CompressedData["
-1:eJx12z2w60YVwHENNC5dULigEHcYxsMwjIEA5jPiK1y+TSDBgRBEIMGQkBgS
-giEBRPiIgQAqXap0qdKlSpcuXarDpUqXDOPzf8z+Z/Kand87Z3fPrmRfae97
-73r6xUefeVuWZf95e5b9r739GR6+tZ8p4i+i/XC0o2gfinYc7YeifUe0s2gn
-0b472neqzaO9U/se9Xu//v6D0U6jfa9axnnfW4xDnDoZ5wNvMQ/jsk76P6R8
-9on5PiJ/VHXN1f9jyv+46v6E6v6k5v2U8j6tuh9W/UU6X4Wph/sg1l/J2Wej
-jfVUmHo+F23sU4VZ9+cVl7MvKI5Z/yPRxr5Wjyj+xWhj/RWmvvto4zpXmP5f
-Sl1hrt+XNT7mPvpKml9hrudXNb+cfU3jY+6jr6euMOv7RrSx3xXmflhEG/tb
-LNJ4hWO8Ts6+mdZbYK4Xjvo6TP9Ho439Kh5N4xWO/e8w98e31B/THzM/Zn+/
-nY5f4Bivwqwfs3+PRRuf8+KxNL9SvFM8ezx18XiaX+Got8Os/zupC7nCzI+p
-fxkt+4fpL3eYz+8T0cb3VIHje6x6Is3vMN9P31V/zP5h1q949r00XmCun9xh
-9u/JaGM/iifTeIW5/pjP9/ejjfurwPRXvMOs/ynVj/m+ULzDfD/9IFruPxzf
-LxXm+slZGW2sP8fcj2WaX2K+D3HU1yje4bj+Peb774fRxnpzzOcRMz/m+wlH
-vY3cyT1m/qfT+nMczwMFjp+HJWZ+HPdDo/E6HD8ve8z8P4qW9WPml0sc9VSK
-N3In95j758dpfblc4Fhfibk/FW/kTuP1mPU/kzrHfB4w8yu/wrGeBsd8ndxj
-nm+eTeP5s2m8ULzE3P846mlwPE91mP1XPPuJ5sfc/4qXilc4Ph8N5v7DsX+9
-+mertJ4cx/N5geM5vlS8wncxP4796zDrVzz7qebHMV6BY74SRz0VjveIRvFO
-4/dy9jPNLxeY9eOYr5IbuVP/HvOe9Fy08R6VP5fmF/gu5sfsv+KN+nc43tt6
-zPzPp/n582l+IZc46q0Ub+RO7uXs59HGe2YuFzjeS0vFKxz1NMrvlN9j5n9B
-87+Qxgsc+1XKlfIbHPV0ci9nL6bj5S+m8UIuccxXyY3yO8z6Me/5a+LRbZ3G
-c3mm/EJeKL98EL+1a8Ur9a/lRm7lTj7JvTzI2S9Sj+VcnsmFvJBLeY1Z/4P4
-ra2V3yi/VX4nn+Re/QfFs1+m843lHHP95eJB/q1dqH+p/LVcybXcaPwW8/2i
-+Enu5QHz+XspHW/8UpqfyzPlF/JC+aXia8z3B456armRW43XySe513yDnL0c
-bXz/j3H0z19O82eY7yd5gVk/jp+Ha3x3ayvNXyveKN7KneY/Kd6r/gHz8/9X
-6XxjHM8rueIzucDx83ghlzjmW6t/heN5qMbxfN0o3mKeL+ST3MuD6sleSccf
-v5Lm54rP5AKzfhzjl/ju1q4xz2+K1xq/0Xit3Cn/hGP/ehzPzwPmvPfXqcc4
-xstx7MdMLnDUs8C8r2j8Nb67tRWO+mrM9Vf/Vvmd8k84nv97xQf1zzbRxvvA
-GMf7co5jPTO5UP+FXGLWj+9ubYVj/2rM+xSO95tW7lTPSfX3OPZj0PjZb1KP
-cYyX43jfnyle4Bh/gWO/S42/VrzS+DXmfRbH9Wox53nqf8KxPz2O/RgUz36b
-9h/LOY75ZpjzAcz1l0sc+7XGnI9pvhpznqT8Fsf5YofjfOkk9zjOFwfM+dur
-aXyM47wufzXNn2Hez+UFjv0ucdSzVrzCsb4ax3406t8qv1N9JxzXq8fc/5jz
-y9fS+cavpfn5a2n+DHM+qPwFjv0rFV9j7n8c17NW/wbH9WmV3+HYjxNm/eo/
-qP7sd6nHOMbPcez/TPkFjvkWmPNKea3xK8Vrjddo/hZznoz5/sPxfdPjuD8H
-zPn/79P5xpjvP8VnOOopcNS/wDF+iWP+tVzJNebzL7fK73Cs9yT3qm9Q/dkf
-0vHHmPNYzP2P+X0B5vrjmL/UeGu5wvz8x3z/a/5W/Tvln5Tfa/xB+VkVbezP
-CMf+jBWfyDmO/Zhi9kvxufoXOPb/Hke9C3mp8Ut5pfHWONa7UT0Vjv3carwa
-x+d9h3k+UX17zPOaxj+ovg7H8+ZRPqn/WfEex/PTRfUNqu+q/OyP0d7d2hHm
-fUCeKD/Hsd4pjvlm6j9XvMBRz728kJear1Q9K+Wvlb9RfoXj/WWreI3jfWWH
-Oe+V91pvq3oOcqf5jpjneeWfVU+v+S8ab1D+Vc5ejzbWP3o9jY9xvF9PlJ/L
-U8z7ksaby4V8Ly/w3a1dYn4fp/lXmPMWjbdRfqX8rfJrHOcHO8Ub9d9jzmvk
-g/p3Gv+o8U6KnzVer/yL8gf5ijn/+1PqEY7zt7E8UX6u+FTxGY765jjqKRS/
-V/+FvJRLzb9SfK3xN4pX8lau5d0D3/40mn+veCsf5E79j4qf5LPye8Uv8iBf
-5ezPqUfyWJ7IuTyVZzjqnSteyPfyQl7KpcZfKb5WfCNXyt/KtbxT/0bey618
-eDDere1w3J9H+SSfMZ9/jXeRB/mq8bK/pB7hGH8sT+Qcx+d5Ks+UP5cLzPe/
-vFB9S7mUV5jfNyi+0fyVvFV+rfXs5Eb17nH8/Gvlg+brcPw8Oir/pPHPmN9n
-q/9FHjTfVc7+ms43wvz8lydyLk813gzz/Ifvbm2h+D2O59eF4kvM+bLGW+FY
-/1r9N5h/z6r+W7lW/g7z7200/l7xVvGDxu9U71Hxk/qf5V75F+3foPwr5v3v
-jWjjfWT0Rhof4xhvonguTzHvfzj2b47j+bZQ/r3GW+B4X1sqv8RxP6ww582a
-b6N6KuVvFa+1/p3Ga1TfHnNeqfUcNH6n8Y4a7ySf1b9X/4v2Z9D8V60n26bj
-jzDnQTjefyeY66/+U8VnOOqbY87P1f8ec56E47xrqfwSx/27wpy3qv6NXGm8
-reqvVe9O9TSaf6/+rfIPWl+n/KPGO6m+s+K9fJEHrfcqZ39L1zeSxzjmn2B+
-P4RjPVMc653huB5z5Rca7x5znqb8pVziuJ9Xqnet9WwUrzT/Vvm15tvJjda7
-x3G+2+I4fz5ofZ3254g5z8dxf5xVb6/5LqpnUP5Vzv6e5o8wvw/B8f9MJmH+
-n0dOPP7fyRRzXoxjv+Y46i0w1x/H9VkovsT8fkn1rjC/b8LxedjIlerbavxa
-9eyU32j/9oq3queg8Tsc9+9R453U/6z97RW/aPwBx/111fXK/pHGR5jfh2A+
-/5jzXxzzT3Hs70zjz3Gst8Cc/2HOfzX/EnP9Nd9K9a/Vf4M5f1c9W8VrrW+n
-+Rrtx175reo9KL9TfUfVf8LxeTlrvF7jXTCff+Vftd7szWhjv0dvpvExjv2Y
-YP59DI7ny6nGm2m8Oeb3p8q/13wLxZfqX8or5a9V30bjV5jPv/rXOO7Pndwo
-f696Wu3XQfN3qu+o8U747taeNX+POf/FvP9p/Cvm33/9M9p4fxvhmG8sTzDn
-v4pP5RmO+uaKF5j3P+Uv5KVcqv6VvFa9G/Wv5K361+q/U36j+F79Wxz7fZA7
-zPkP5t+zKf+seK/4ReMN8lXO/pV6hDn/kSfKzxWfyjMc509z9S/ke+Uv5KXG
-L+UV5v1f/Tear1J8q3iN4zxpJzfyXv1bxQ9yJx/lk3yWe9V/kQflX+Xs36lH
-OP6M5Ymcy1N5Js//7/8CjqUk5g==
-           "]]}, {
-          Hue[0.08640786499873876, 0.6, 0.6], 
-          Directive[
-           PointSize[0.002777777777777778], 
-           AbsoluteThickness[1.6], 
-           RGBColor[0.941176, 0.906538, 0.834043]], 
-          LineBox[CompressedData["
-1:eJxd2juQ81YVwHENNC5dULigEB6G2WEYxryXZ8R7Q3g4IQmbhId4BAwJiXiE
-mLcCBAwEonJLlS5VulTpUqVLdWyp0iXD+PyXuX83d35zzj3nXknWSv6+d3zv
-5Seef0uWZf95a5b9b7x8pkfSMSsuwyLGmcZ5jG+P8W3yQuPbNeaat1Tddyr/
-XYpfaT3vVvw96v9e9VvFyD7fFyP7f7/yP6D6H9T6PqT8D6v+RxS/1vo+qnof
-i3EZ48dj5Lh9Ikb2/0n5U+r/iPoV6XpqOft0Wq/GrO8zaf0as77Pqj5m/ufS
-/FrOPp/m15jj/wXFMev/ouKY/d+oP17G+Gjar35U8S+l/WpM/cdi5Pg8pviX
-Fces/yuqj5n/1RjZH2Z9X1Mc871ZxxjfiwJzPHD07zH9H0/rFzi+t/XjaX6P
-+V4+EWN8rwvM8cZRv8fcF76errfAzFe8x9wnnkxdPJnm1zj69Zj9P5X2KzDn
-66k0v1c8e1rzn07za7yM+ZjvzzdijPNZYObj+P72mO/XbepCrjHrx3z/nknj
-xTNpvFa8x6z/2TS/wBy/Z9P8HnP8n4sxzk+BlzH/uTS/x+z/m2n94ptpfo25
-/jHzv5XGCxzfpxqzfsz6v526wHx/MNcvXsb4nTReYNYv95jjX8YYxz+XCxzX
-T4k5PziuvxbTT/mj4tl30/XkeBn9FS8x+1O8lXvlj5jz9z31lwu5xOwfR/1W
-8R7H8Rzl7PsxxvHNMf1x1C/xMvrj+PvRKr9X/qh49oN0PTmO9RQ4jlcp1zj2
-22KOv/JH9cueT9eTY+5nipeY44+jXqt4L4/Kz34YYxy/HLN/xUtMf+W3OJ4f
-exzf5xFz/f0oXU+OY36B6Y/pj+mv/F7xUc42ab18k8YLxUvM/R1z/Wt+j2M9
-o5z9WP0x9x/FS8zzEo7j1WKuf80fVT/7SbreXC4w/eVa+S3m+Cs+Yt4vXkjz
-c7l4Ic0vMc/jmOtf7uVR87MX1f/FNF48xC+fUvEac/xVr1d8VL3sp2k8x/RX
-vJRrzP1P8V4e5eyldH4uFy+l+aVcK7/FXP+Kj3L2Mr58csz3X/FS8VrxVu6V
-P2LOf5WuZ/7gWI+8kgt5LZdyhVm/4o3W0yreyb08yKM8ydnPUs/lXF7JhbyW
-S7mSa7mRW7mTe3mQR3mSs5+nnsu5vJILeS2XciXXciO3cif38iCP8iRnvwjH
-9TiXc3klFzg+a7l88GWsNL9WfiO3mt9h7i847u+D6o/Kn1Qv+2Xab47Zv7zC
-3J/ltfJLuZJr9W8Ubx/il7FTv17zB80fNX+Ss1fS/PkraTxXfCUXmP1rfilX
-ml8r3sit8jv165U/yKM8ydmv0vpzzPOY4ivM+Vd8LZfKr1S/VrzBy8vYYs6/
-6vc43jcG1RvlSfOzV9P681fT/FzxlVzg+P6tMc+LcoV5f1W8UbzVejrM+5XW
-Myh/VP4kZ9s0f445/5j9ywWOemvNL3Hsp1K/Wm4wz7MP/S6fTvV79R8w75ta
-76T1ZL9OPcfLy5jjWM9K+QWO+mvFSxzrqTD7lxvM+7TqdVpfr/xB+aPWP8nZ
-b9L1zeVcXmF+n8DRb41jfaXyK9Wrld9gzr/qd5rfa/4gj8qfMM+/v03jc8z1
-jzn/mPsfZv843vdLuVK9GsfxaVSv1Xo61euVP8ij+k2Y3/9/F2P8XjnH/B6D
-o/9KLnD8fr/Gy8tYYq5/xWv1a1S/VX6H498PetUflD+q3qR+2e/T+Bxz/1d8
-JReY8y+XcoX59xi5kVv16+Qes3/NH9V/0vzsDzEuL+Mc8/yHuf4x9z/M/R/H
-9VAqv5JrzW8Ub+UOs3/NH7SfEXP/V372x7T+HMf3K8fc/zD3P81fY/7+KV6p
-Xq14g7n/qV6Hef7T/EHzR8UnOavT9cxwzJ/j6LeQc+VfYZ4X5GvM9wfH8bzR
-etY4rsdbzS9x7GejepW81XprxXeq1yj/TvtvNX+v9XWqd1C81/yj+g2af1J8
-xMvLeK/8ST7r+GavpZ69lubPcax3ofwcc/5x7GeF43hdy4X63ajeWvm3Wk+p
-+EbzKxzX31bxWt7JjebfaX+t1r+XO/mg9fbyUf0GvLyMJ/Uftd57zZ8UP2s9
-2Z/S/jPM30N5gXk+UPxKXsnX6lfIN5jnacVvMe+XOPa3Ub9K9baaXyu+kxv5
-TvVbea/87sGXz0Hr7bWeo/IH1TvJI47jc696k3zW/OzPqWfy/MGXzwLzfCBf
-ySv5WvUK+Ub5a/lWLuWNXMlbuVb/neKNfKfj02r+HvO+rvhB9XrVOyp/kE+a
-P8r38qT5Z8Wzv6SeyXMcn4WcK/9KXsnXml/IN/JavpVLeSNX8lau5Z3cyHdy
-K+/lTj7IvY7PUfFB8ZPio3wvT5p/Vjx7HV/G2etpfC4v5Fzzr+QV5u8/5vkP
-x/puNH+N4355q3ip+hu5Uv2t1l8rf6f6jfLv5Fb5e/XrVP+geK96R8UH+aT8
-Uf3vlT/JZ+Vnf009k+c45i8Uz3Hs70peaf615hfyjbzW/FvFS8zff+VXyt8q
-v9Z6d8pvlH+H+fuv/L36d4ofFO/V/6h+g3xS/1Hz7+VJ/c6ql/0tXd9MnuPl
-ZVxgfh/DnH8cz4cr+VrzC8z7n/qvFb9Vv1L1Npjnf3mr9dQ43md26t9o/p36
-tVrPXu5U76B4r3pHeVD/k47HqPr3yp+0v7Pi2S7G5WWcYZ7/FV9gvv+Y9z/M
-+cex3mvVL1TvRl4r/xbHfkocv2du1L9S/63q1drfDsfvP43m36l/q/he9Tvl
-H5Tfq99R6x90fE84fl8bVf9e+ZN81n6zv6frneFYzxzHehaY938c+7lS/kq+
-xtG/UP8bzPu/fKv+pfpv5Er1tziurxrH8dypX6P8O8Vb7Wev/p36H3Bcr73q
-HeVB9U6qN8r3Oj6T4mfVz/4RI+//mN9/cKx3gTn/yr9SfIX5/mP+vz9eXsYb
-zV+r/i3m9x8c1+tGrrS/rerV8g5z/9f673D8+0Or9e+1vk71D9pfr/yj8gf1
-P2n+iPn9R/mT9n/GvP/9M+03k+c49rfA/P6r/CvM73+af614gWM/N/JavsWc
-f9XbKL+St1p/rfXv5Abz91/1WsX3Wl+n9R3Uv9f8o+oPyj9pfaPq36v/pPpn
-xbM3Yozvywzz76FvpPkLOcfc/zHvf6p3rfkF5v1P89eY+z/m+U/eqF4lb1Wv
-Vnyn/o3We6d+rfL3D758OvU74OVl7HX8jqo/qP5J8VG+13on+Sxn/0rXN5Pn
-OPovML//Yn7/xfz+g3n/V/1C8RvVWyt+q/WUqrdRvNJ6tqpXq99O8xvNv1O8
-lfdyp/oHxXut5ygP6n/S/FH7v1d8ks+qn/07rT/DPP9jzr/yc8Wv5BXm+U/x
-QvVu5DXm/Cteqt5GrjR/q3j94MtnJzfqdye38l7u1O8g9+p31PxB+Sflj/K9
-5k+KnxXP3kzrz95M4/OH+OWzkHP5Sl7J1//3fwF3Wweq
-           
-           "]]}}}, {}, {}, {{}, {}}, {{}, {}}}, {
-      DisplayFunction -> Identity, PlotRangePadding -> {{
-          Scaled[0.02], 
-          Scaled[0.02]}, {0, 
-          Scaled[0.05]}}, AxesOrigin -> {0., 0}, 
-       PlotRange -> {{0., 999.}, {0, 37.}}, PlotRangeClipping -> True, 
-       ImagePadding -> All, DisplayFunction -> Identity, AspectRatio -> 
-       NCache[GoldenRatio^(-1), 0.6180339887498948], Axes -> {True, True}, 
-       AxesLabel -> {None, None}, AxesOrigin -> {0., 0}, DisplayFunction :> 
-       Identity, Frame -> {{True, True}, {True, True}}, 
-       FrameLabel -> {{None, None}, {None, None}}, FrameStyle -> Directive[
-         GrayLevel[0.5], 
-         Thickness[Large]], 
-       FrameTicks -> {{Automatic, Automatic}, {Automatic, Automatic}}, 
-       GridLines -> {Automatic, Automatic}, GridLinesStyle -> Directive[
-         GrayLevel[0.5, 0.4]], ImageSize -> 750, 
-       Method -> {"CoordinatesToolOptions" -> {"DisplayFunction" -> ({
-             (Identity[#]& )[
-              Part[#, 1]], 
-             (Identity[#]& )[
-              Part[#, 2]]}& ), "CopiedValueFunction" -> ({
-             (Identity[#]& )[
-              Part[#, 1]], 
-             (Identity[#]& )[
-              Part[#, 2]]}& )}}, PlotRange -> {{0., 999.}, {0, 37.}}, 
-       PlotRangeClipping -> True, PlotRangePadding -> {{
-          Scaled[0.02], 
-          Scaled[0.02]}, {0, 
-          Scaled[0.05]}}, Ticks -> {Automatic, Automatic}}],FormBox[
-      FormBox[
-       TemplateBox[{
-        "\"F\"", "\"B\"", "\"R\"", "\"L\"", "\"O\"", "\"M\"", "\"S\""}, 
-        "LineLegend", DisplayFunction -> (FormBox[
-          StyleBox[
-           StyleBox[
+               ",", 
+               RowBox[{"Joined", "\[Rule]", 
+                 RowBox[{"{", 
+                   RowBox[{"True", ",", "True", ",", "True"}], "}"}]}], ",", 
+               RowBox[{"LabelStyle", "\[Rule]", 
+                 RowBox[{"{", "}"}]}], ",", 
+               RowBox[{"LegendLayout", "\[Rule]", "\"Column\""}]}], "]"}]& ), 
+          Editable -> True], TraditionalForm], TraditionalForm]},
+      "Legended",
+      DisplayFunction->(GridBox[{{
+          TagBox[
+           ItemBox[
             PaneBox[
-             TagBox[
-              GridBox[{{
-                 TagBox[
-                  GridBox[{{
+             TagBox[#, "SkipImageSizeLevel"], Alignment -> {Center, Baseline},
+              BaselinePosition -> Baseline], DefaultBaseStyle -> "Labeled"], 
+           "SkipImageSizeLevel"], 
+          ItemBox[#2, DefaultBaseStyle -> "LabeledLabel"]}}, 
+        GridBoxAlignment -> {"Columns" -> {{Center}}, "Rows" -> {{Center}}}, 
+        AutoDelete -> False, GridBoxItemSize -> Automatic, 
+        BaselinePosition -> {1, 1}]& ),
+      Editable->True,
+      InterpretationFunction->(RowBox[{"Legended", "[", 
+         RowBox[{#, ",", 
+           RowBox[{"Placed", "[", 
+             RowBox[{#2, ",", "After"}], "]"}]}], "]"}]& )]},
+    {
+     RotationBox[
+      StyleBox["\<\"Female\"\>",
+       StripOnInput->False,
+       FontSize->30],
+      BoxRotation->1.5707963267948966`], 
+     TemplateBox[{GraphicsBox[{{}, {{{}, {}, {
+            Hue[0.67, 0.6, 0.6], 
+            Directive[
+             PointSize[0.002777777777777778], 
+             AbsoluteThickness[1.6], 
+             RGBColor[0.293416, 0.0574044, 0.529412]], 
+            LineBox[CompressedData["
+1:eJxd2T1w7FYVwHENlUsVFC4oxA7DeBiGWb7NZ8S3+YxICJhAiAg8cHgJEZAE
+85VcCAGXW7pU6VKly1u+UqVLlW6YUekSmD3/nbn/Ld6d3zvnnnN1pdXuyu9/
+6bVnHr2nqqr//O+f/4/71/rUfvxAG/8R40djPIrxJMY6xg/H+N4YPxTjcYwf
+jPF9+v9G/79RH6+DOvT1OujLOlgX/T6ivlvFOU7qfUzr+7jqf0L5n9T6P6Xj
++LT6n6reZ1Tvs+r/OfnzMXLcX5C/qH5PaT1tjJv9mDDr+VLZL2H2/ctlvYQ5
+T19RHLP+ryqOmf81xeXq64pj1v8NxTH7cVbmJ8x18s0Y4zpImOvmWzHGdZEw
+878dY1yHCW9i/I7Wh9nf78YY5zNh6n+vzE+Y43u67JeeVryLMfa77ZTflfkZ
+s//fjzHOZ4tZD476WfHqGfV/pownxbPi1bPl+tpny/yEY78y5n37g7Jeizcx
+H8d9IcvVc2X99rkynhTPmOv7hzHGfrZywrGejHl//0jrlxNmPua+eF6up8XM
+x5x/TP8fa/2Y+wWOehmzf8+X62mfL/MTZv2Y/j+JMd6PLY79Tjjuyxlz/D8t
+67WY/Vc8Y66/F8p+Leb6e6HMz5j7389Kt3gT8+WMuX5ejJHrH7P/imcc9aq+
+rNfIbV/m9zjqJRz9Rjnj2L9F9aufxxj73WD2A8f8XvGk+SOO9WZ5UX71Uozx
+edvg+D7Q4jjeHnN+lT/iqJ9xfB9Y1K/6RYxxPI3cyr2c5BHTX14w1+8vy/U3
+mOsJ01/xhDfRH/N+wbFfi/KrR2X95lEZb3HM7zH3B8z+Y44fx3oX1at+VeY3
+OM5Xi6N+r/yEo/6IY/1ZXlSv+nWM8f2jwZx/zPWHY37S/FHOmP6qV12UbnDM
+bzHHr3jCsV8jjus7K75gvs+/XMabl8t4q3iveFJ8lDOO9S9y9ZvyeBpMf0x/
+zP4rf8TxOyrj2I9F/arHZb3mcZnfPi7ze8WT4qOcVX/B7P8rpZtXyvwWR78e
+x34kHMc7Kj+r/nJwvF4t5zevlvktpr/ykzzK+VBv/1rk6rdlv0ZucdTrD/H9
+Kyk+ylle5Oo19cecf8z1p3jS/BHT/xDfvxbFq6GM10MZbxTfyq3cyb3qDXKS
+d5o/ypOc5Vle5FWufle6lht5K7dyJ/fyICd5J4849mdSPMuz8hd5PeTH+Pty
+fi038lZucdTvFO/lQU4H78edPKr+pPlZ8VnxRfVWzPOZP5T5Neb6V3wrt8rv
+DvH92OPoN8gJx/t5p/mj+k2KZ8VnedH6Vrl6vaxXH7x/Na+X+Vu5VX6neC8P
+mOOXd1rPKE/Kz6o/ywuOz7NVrt4o69WY7wNvlPlb5bc41tdhPq/kQfkJc/+T
+R+VPctZ6Zq1/Uf9V86s3y3613LxZ5m8xx4+jfqd4j2P/Bsz3R83fYb5PK3/C
+m/2Y5VlecHzfXxWv/ljWr+UGx3q2mOcdcoc5fs0flJ9w7M9O/UfNnxTPis+q
+t8gr5vfnZYyb/Vhjfg/h+D2yxXw/1PwO83tF9QbM80zFdzjO16j+k/pleZYX
+HM9nVtWv/lS6xvwewlFvq/xW7nAcT4/jedOg/CTv1G+UJ60va/6sfguO52Mr
+5vnxn2OM39M1jn4N5v6HOX4c56dTfq96A+b6V/5O9Ud5why/POM4vgXHfqyY
+v+P8JUaOH3P941j/FnP8coe5/lV/UDxhjl/9R8z9T86aP2Oet6neqvVWfy3X
+V+OY3+DYzy3m+RDm/oc3+7GXB8z1r3o71RuVPyk/Y45f8UXxVfWqv5Xrq+UG
+x/5sMc+LcdTvMM/LVG9QPOHY353qj5j7P+bvIVrfrPoL5vyrfvVWWa9+q8xv
+MJ9/mOdTmt8p3uPNfhwwn//qt8OxH6PmT5jn6YrPii9a/ypXb5frqd8u4w3m
+8w/z+a94h2M9PY79GZSflL9T/VGe5Izj/jar3oJjP1bFq1TWO0plfp3K/GPM
+/uDYvxPMfil+inm+ovwzzPdJHN+nzuVe8y+0vkH1LrWepPiV6u1U71r9Rxzv
+/xt5km9VL8tPVH/Weu50Phadv3v1WxV/0Pmt/l7mH+HoV+Pod6x4g6PeCY79
+3Sp+inn/4DjeM/XrcFwv51pvr34X8qD5l+qX5Ct5p3rXOv5R+Tc4rqdJ+bc6
+vow5/8qfFb+TF/W/l1et/wHz+/8fZf6RXOPod4z5fSSfyFvVO1W8VfwMx6vD
+sd5zuT/k78cLeZAvNT+p/5XiO82/Vv4o32j+pPitnA/1968nis+K38mL8u/V
+f5UfNL96B+/Ho3fK/Frx44P3r0b5J8rfyqfKb1XvTO6Uf465/6v+hfIH1btU
+PCl+pfhOvla/UfEb1ZvkWznLT+RZvpMX+V5e5Qe5+mfpI7mWj+VGPpG38qnc
+4ti/M8U7+VzuNf9CHuRLzU8H78creSdfa/4o36jfpPit6mX5iTzLd6q/YN7/
+OO6vq/o/aH71bln/SK7fLfOPFW/kE8z9X/FT1WsP8f3rTPmdfC73OI7/AvO8
+Vf0u5aR6V1rPTvFrzR/lG61nUvxW9bPqP9H8Wb6TF9W/V/1V+Q86P9W/yvgR
+5vzj2M9j5TfyCebvBYqfql6r+BmO9XU4vu+dK7/Xei80f9D8SzlpPVeqt5Ov
+lT/qeG+UP2m9t4pnzPc/rW/W8dzJi9Zzr36r4g94E+O/Sx/h6F9jzr/ijXyC
++f2n+afq18pnqtcpfo55vobj9/UFPmn/C2X1aj8=
+             "]]}, {
+            Hue[0.9060679774997897, 0.6, 0.6], 
+            Directive[
+             PointSize[0.002777777777777778], 
+             AbsoluteThickness[1.6], 
+             RGBColor[0.4286185, 0.2924847, 0.7194555]], 
+            LineBox[CompressedData["
+1:eJxd2DlwNEcZgOEuIoUTOFBAMKgoSkVR1HKL04MNWNyLucRlxoYf1hjswVwC
+g93cCjdUOKHCCRV2qHBDhRMqoWpChUDt966r3w3+ruf/jj5mdla773rpteef
+vCOl9J///fP/cf9ant6PT3XxHzE2MR7F+E79/1MajzW+W3UnMbYaTzRSxzzv
+kU8173u1zvfFyD7eL69iZN8fUL8Par4PyR+WPxIj+/6o/LEY2e+Z4h/X+j8R
+40mMn1T9p2LkXD8dI/v7jPo/rfyudsb0/2y9niynZ+r++RnFn63Xn59V/HMx
+xvllzPl/XnFM/Re0Pkz9c6p/TvHzGOO8spy+GCPng7nPvhTjScQx9+WXVY+5
+Hl+JMc47y+mrqse8L76m+TH1X6/ny5j7dR1jnEeHo3/G0b9g3i/fUD1mPhzz
+FcXT86rHnAdmfkz9N1WPuR9w9CuY+m/V7jD3i+JF8fTt2h3meuE4z4JjP+k7
+McZzrcOcH479FMz9+d0Y2T+mHjO/8tNFnd9h1q94wdR/L8Y43w6fRL1clJ++
+X6+vkzOO+Qrm/H+g9eM4z4xjP0Xx9MN6fR3m/DDzy+lH9X46zPox54djvvSC
+5n+hzs+Y+RVPP44x9tdhnmeYejn1dX6L6Sf3mPcHjn6j4gXH/TsrP71Y76d9
+sY53cq/8jKP/iHm/47geM+b6v1THW8z9JPeY5xNm/8ovOM5vltNParc49tPh
+uD694hnH83hUv4JPYn7M/n8aY1yvFjO/3MtZ9SOO9RQc5zHL6Undr5W7J3V+
+jzl/HPsZVV/kGXP//ax2i3k/Y/aPuf9xnPeofgXH9ZsVTz+v+7c4zq/DXH/F
+M+b81a/Is/LTpl5/u6njHWb/cpZH1Rd5xvz98HLt9uU6v1O8x8yv+Kh4wZy/
+nH6h+TH3H+b5o/yMo9+oeDnE969ZTq9o/lfqeHdwzK/8LI+Y88dcf8XTL+v+
+Leb+U7zH3P+Kj6ov8iynX9VuMeeveC9necSxniLPB8frVc3/ah3vDt6PPeb+
+U/6ofkWelZ9e0/yv1fFO8V7xLI9yUf0spyEc+2lwvFp5JXc4+q0V7+VBzvJW
+/cZDfD9Oyi/yTp7lRU6/rt3IrbySO3kt9/IgZ3krj/KEub8U38mz8hfF0+t4
+Pzav1/FWXsmdvJZ7eZCzvJVHeZKLvJNnzP7l9JvaDY5Xq/hK8U7x9SG+H3t5
+UH2Wt5jPU9VPihd5p/XM6r/I6bd1foP5PFB8pXin+Frx/uD9a5Cz6reqHxWf
+5CLvMJ93ii+Kp9/VbjB/D2P2j9m/8teH+P7Vq36Qs7xV/1HxSestiu80/ywv
+Wm/6fYzx902Duf445lspv8PsX+7Vb5AzZv/yqPknxYviO61vxvH9YZHTH+r8
+BvN5jNk/5vuxvMZ8X8FxHoPmyzi+b2zlEfP+V/+i/jvFZ823qH+6rOMN5vrj
+6L/C7F/xNY7+vfoNmPtf82/Vf5Qn9SuY63+I71+z+i/ql/5Yr7/B/B6Bo36l
+eCevMb+XyAPm9ykcvz9sNd+I4zwnzVfUf6f9zPKi/PSn2g1m//IKn+zHDnP9
+Mc9/zPNP82XM/a9+ozxhnn/yTvPPWv+i+dMb9X6aN+p4i9k/5vknr3Fcz179
+BszvF5p/q36j8ifFC+b5j9m/+i/ql/5c92vkFkf9CvN7Neb+x1x/9RvkLG8x
+11/xCfP7lrxT/qz1LXL6S13fYPaPef5h3v+qX+OT/dgrPqh/Vr+t6kcc99Ok
++oLjeu7Ub9b6F60nvVnnN2/W8Razf8zvYzjef2sc6+8x11/zZfXfyiNm/5q/
+qP9O9bPyF+0vvRUj338wv8e9Veev5A5z/2N+L5IHfLIfM2b/yh/lCbN/rWen
+frO8KD/luv8Rjv4Njvf7MY71t8o/xXGeK/U/w/y+J59j3k+qv9B8vebb4Lh+
+A47rc6l4Vv2VvNX6rrX/Uf1v5Enrv1W8KH6n+E7xe8Vn+UH7W+RHzPffv4bj
+PI8wz0Mc53GM+X6EY32nmM9LHPOfKb9T/vlhvv1rrfwL9eu1no3WO6j+UvGs
++JXiWxznda31jcq/kSfV36q+aP13Ws9O+71X/1n1D4ovqn+U09/q/CPM7wGK
+H2Ouv/JP5ZV8pn6d+p1jPk/kC9X3B+9fG803KP9S8SxfYf4e0fzX6jfKN+o3
+ybdab8Fcf+XvtJ57xWf5QetZNN+j8tPf6/iR3By8H4/lFnP9Vb9S/Azz/Fe/
+c+Wv1e9C8V7xjeKD4pdyVv6V4lv5Wh7lG/WbFL+Vi3wn7+R7eZYf5EV+lNM/
+ah/JjXwst/KpvJLP5E4+x1x/xS8U7xXfyIN8qfp8iO/HK+Vv5Wvlj/KN8if5
+Vi5az528U/69PCv/QV5wPD8eFU//rH2E49Uofiy3h/z9eKr6FY73+5nyO/lc
+9WvFLzCf/4pvtL5BvlR+VvxK8a3i14qPit/Ik/Z/q3jRfu+Uv1P+veafdR4P
+8qL6R82X/lXnH8mNfCy38inm818+U36H4/48x/yepPwLuZc38qD+l4pnzPtf
+82+Vf638UfEbxSft/1b5Rfl3iu8Uv5dnzN//2u+i/TyqPv27zj/CJ/uxwVF/
+jLn+mM9/5a/kM9V3mPc/5vu0fKH6Xt68vZ7/AunFcUo=
+             "]]}, {
+            Hue[0.1421359549995791, 0.6, 0.6], 
+            Directive[
+             PointSize[0.002777777777777778], 
+             AbsoluteThickness[1.6], 
+             RGBColor[0.563821, 0.527565, 0.909499]], 
+            LineBox[CompressedData["
+1:eJxd2Tlw7UgVgGEVkcMbEDggEC6KclEUJXazjhhgMMuAGDYzbGKYN5hheQIG
+xuz9WB0qdKjQoUKHHTpU6FChE6oUOgTqnt9U/w6m56tz+nSru3Wvrt7bX3n6
+0pO3VFX17//+53/t/m97Lv6nLdujaA+ifVe0O/mtag+V9za1tcw49HtHtO9U
+S96xzDzo/275PZpfo/7vVfx96v9+zesDmtcHFf+Q/GHN80T9P6L4RzW/jyn/
+44p/Qv6kxn8uWta9LeslzLp9KtpY5yRXz5fjJbn6dDlewsznM9HG/idM/88q
+jtmfF1T/BcU/p/lhzttptLG/CdP/84pj+n8hWtYHc66+WDphztGXoo39Tphz
++GLp9GKZX3052jjXCXM+vhJtrHfC7H8XbVxvi7leHPUy5nx8Ndqj6I/ZDxzX
+nzHzfynaWL8WR72EY/5Z+dXXyvotjvklOWPW9+vRxn3cYu4HHOuRFa++Uc63
+xbGeCTN/zPjfjDbOQ4vjcyFh1g9z/d+KNtazxZwHHPuRMf3PyutpMf3xUfTH
+3L/fVn/M/YoZH/N98HK0sb7ty2V+woyPOT/fKa+nlRNm/TH7991o43y0mPtR
+8YxZv+9pfMz5UTxjvk++X7rFR9EfM3/M+D8ox2sx5x/HfmZM/76sX8stjv3o
+MfPDUW/CrJf6r+pf/TDaOC81Znwc19dj9hfH9U2KZxzjrZj1f6WsX2PuJxzz
+6ZWflD9hzrv6r5jvjx9FG89VNeY84Jh/r3jC8XkzqV5WfMWM/2q0sV81Zv1f
+LfN7OeEYb8J8XuK431fFqyfRsv5PyniLGR8fxfjyhDl/8or5/Hot2tivGsd4
+reK94kmeMOcPMz7m+n8cLfuPY71aucd8v6j/hOM5Piu+ql51XtarMfuPY749
+5vMZc/2qlxVfVa/6STmfGsd8W8z+K57kCXP9OH7HrIpXr2v818v8Vu4x64/j
+eiYc883KXzG/o35K/f1f/egYX+4x16/+k5yVv2Lu/59Fe7Rva8z5wzH/HjO+
+8ifFs+KrXP28dI1jf1oc9XrM55/iE471yvKq8apflOPVmPOHWX/lJ+VPOOpn
+5a9y9ZT6+7/6aRlv5V75SZ7kLK9yNZTeYdZDbuRW7lSvlwc5yaM8ybPGy4ov
+8ipvcvXL0ju5lhu5lTu5lwc5yaM8ybOccazHovgqb3L1q9K7R+/bWm4w+6/+
+neK94oOc5FHjTTjupxnz+aLxFvVf5U2ufl3W38k15vzLrdxhPi/kQU7yqHoT
+juudFc+P/fd/i/JXedN41RtlvR2Ov/qNMr9Rfit3co9j/EH1kjzKk/rPmM9X
+xRf1X+VNrn5T9t9hnodwfF82covjeaiTe9UbMO9jcHyfjcqfNL9Zzuq/KL6q
+3iZXv402/naP3re14o3iLY7xOszzojzg2L+k/iPm/Ct/Vr0sL6q3Yq5f9ao3
+y/47zO/RN8v8BvO+TP07zP6r/6D6Sf1HeZJn1c/4aN8uOH6Prjh+X21ydVHW
+3+GoV+MYr1G8xVGvwzyv4/g9NKh/0vij+k84ft/PON7XZRzv0xbM9Wv+m1z9
+rpzPDsd8axz3a4O5/xXv1L9X/QHz+0H1RuVPOOY7K57lRfVWHOu7qV71+2hj
+vXaY9wE4rqfBMV6L2X8c+9Wr/4D5/SiPmP3XeLPGy+q/KH9V/ob5/fmHaLl+
+zP5j9h/zvg3HeB3m/sexngOO971J448ab9J4s5w13wWz/zg+fzbNr/pjWW+H
+Y31qzPcf5v2A+neK9+o/KD/JI475Tao3Kz/jWL8Fx/lb1X/DR9H+KVo+/zD7
+LzeY94OKd3KPY74D5t9zcMxnxHFeJhzv/2flZxzXt2i8Vd40v+rP5Xg7ucax
+no3iLWb/Mecfs/+Y5x8c1zPKE+b7T+NlzPlXfNX8N8y/H/wl2rgfd5j34TjG
+bzDf/4p3iveY/ZeTPGLeJys+y1n5C+b846N9uym/StHG+h2kMn8nH8o1jnrH
+coPjvJxgvj9xfD6dYp4nlX+GOV/yufIH1btQftL1XOLY/1HxK3nS9V7LM479
+ulH9rPncqv+i67nDcd5Wzede+7mp/oPyq2dl/YNnZf7uWZl/KNfqf4y5X3Dc
+DyeKt/Kp6nfymcbrNd9zzPM2Zv81XlL/S813VL0r9Z/ka9WbFb9R/az53Wq8
+Rfl38qr691qvTfN5kKu/lv0PMO9DcPzeO8S8H8Qx/2P1bzD7r/xWPlV+p3pn
+cq/+55rvIF+of9J4l8ofVf9KnjD7r/iMY71u5Kz8W81vke/kVfO9lzeN9yBX
+fyM/piHv5EPM/it+rHjzGN+3J4q38qncqf+Z3GP2X/MZVO9CTvKlPMpXqj/J
+1/Is38hZvpUX+U5e5Xt5kx/k6u+lD+SdfCjX8rHcyCdyK5/KnXwm9zj251zx
+QfELOcmX8qh6V/IkX8uzfCNn+VZeNJ+7x/i+XXF8Htwrf1O9B8Wrf5Q+kHfy
+oVzLxzjuxwZz/2P+fVE+lTv1P9N4veLn8qB6F3JS/qXqj4pfyZPyrx/j+79Z
++TdanyzfKn/BfP8rf8V8/6v/pv4PcvXPMv8A8z5cPsS8H1D8GEf9Bsd6nyi/
+lU/lTj7DPP9pvHONNyh+gXn+x/E8fomP9u0oX6n+pPrXyp8Vv9H6ZdW7Vf9F
++XfKX1X/Xt5U7wHz/vdfZfwA8/yHY30OFa8xz/9yg2O9TzDvz3DM91T1OxzX
+f6b59hrv/P/5/wFD42S4
+             "]]}, {
+            Hue[0.37820393249936934`, 0.6, 0.6], 
+            Directive[
+             PointSize[0.002777777777777778], 
+             AbsoluteThickness[1.6], 
+             RGBColor[0.663226, 0.6872815, 0.9117649999999999]], 
+            LineBox[CompressedData["
+1:eJxd2Ttw/FYVgPE7VC63oHBBIXYyjIdhGPE2zyiBgHklm4SHwyNRQhIMScgC
+CXF4hAshxKVKlypdqnR5S5dbulTphhmVLoHZ83nmfi5y55dzz7nnSlqtVv+P
+v/TmM698JKX0n//95//j/m95tB5TV48HGlcxNjF+NMZ1jIcxfkzjJ5RHvbXm
+PaK65LHukdb5pOp+Sv1/Wvmt6n9G/qz6+Zz6/Tz14+8Lin9R631J8WP1+2Wt
+95UY2edXY+Q4fE3zv65634iR4/hojOsYu7q/jNn/Y3V+xuQ/HmMc/4xZ/5sx
+xnnJmPxv1fMzpt8nlI/J/3aMsf+MOT7fURxznZzU8zOm/+8qX07fq/vNmPP1
+/RjjOsuY6+gHqo/p/4d1vxlznT6p+k8q/lTdT35K8U2M8TnpNpqPo5+COT9P
+K//pen7GcT0VxdMz9Xod5njKBZP/bIzryH+2jme5yOlH6l/OmPUx+T9W/5h8
+TD4m/ycxxvnt5IzjvlUUTz9VPmb/cpHTaYxx/XVyxlG/YD4fz8UY++ueq+MZ
+x/2laH76mfIx/eM4nkVOP6/76zD947jeC+bz+Yt6vQ5z/ckFk//LGOP+12HO
+PyZf8fR8Xa97vp6fMecPr2N8IUb2jzn+OPormPtXX7vBUb/D0W+PuT5x9Ddi
+9qv5s9ZLL9b9Ni/W8U7xHvN9pfmj4kWeMc8LL9X9NjjW6/A61sdcX4qPyi+q
+Pys//ap2g+N+2eF4HutxrJdx1B/lovqz6qeXtT6O55MOc/xx5GfNHzHXm+rP
+iqdX6voN5npWvMfxPJdx9DPidayPWV/x9GqMnH/M+Ve8VzzLI47jUTDXn+ql
+X8cYn58GR38djv31mOtP8VHxonoz5nn0LMY4H43cYY4/5vzjqDdqfpFnzPX/
+G62Puf5x1O8xx1/zRxz306L4rHrptzHG9dRgrn+5x/F5zDj6HzH7x1x/qpde
+q93g6K+Teznj6H+Ui+rPiqfX6/00r9fzO7nHHH/M/Rdz/8Wx3iynN+r6Deb6
+e6Oe32OOP2Z9zPqqP8vpdzHG9dHgqN/JPY6//OBYX/ML5vOveHqzzm8eHP9X
+7jH7x9x/FS/Kn+W0rb16cPQjt5jjI2/kXt6qXtb6gzzKk+oVeaf5s+KL1k+/
+r+MrucHx18qdvJF7eStneZBHeZKLvJNneZHTH2qv5AbH8WgV7xTfKN7LWznL
+gzyq/vQQ349F3mn+rPgipz/W81dyg+Pz1eLI7x68/9vIvbxV/SwP8qj1JsWL
+4jvFZ62/KJ7eqvNXb9XxRm41v1N8o3gvb+Ws/OEhvv8bFZ/kguP87FR/xnH/
+XTQ/vR1j3P9XmP2/Xc9vMd/PONbbyD2O77Ot6mWtP2j+KE+qX+Sd6s+KL3L6
+U72fldzIrdzJGxz99ji+n7dyxvE8MSg+qt6k9QqO47dT/qz4onrpnXr+CrP/
+d+r5reIdjvobuVf9reIZx++BAfN7Asfvg0nxono79Ttr/UXxdF57JTc48lvM
+8zmO5+0N5nkVR79b1c+KD5j3CYpP6qfgOH47zPsGvN6Pi9ZP79bxldy8W89v
+Fe9w9LfR/F7zt3KWB3nEsb8Js3/FdzjeF87qZ1G/6c+1V5jfozjOb4t5P4P5
+/GP2j2M/WznLA473TaPWnzDvN3Cc753qzdrPovrpL3X+CvM+BEd+i3lfibn+
+5V75W8z7QRzvJwcc7/NH5U9av6jfHeb3tvIXzO/fv9b1VnIjt5j3pZj9yz2O
+/Wwxvx81f1B81PqT4gWzf8z9T14w77/+FmOcjxVm/5jrH/N+SN4ov8dxfW3x
+ej9m1R8w9z/1N8lF+TvM95/mL6qf3qv7X2Hu/+/V81u5w7HfjeK96m21XsY8
+/2j+iNf7cZIL5vwrPqv+ovnp7zHG8VvhOF8N5vqXO83fYN6XYb7/Fc+KD5j9
+q79J+QXz/IvjfM/KX9R/yvX8g1zHV/Ihju+XBq/345HqtTjWP5Y75Z9gPk84
+ju8pjuPVK/9M8a3qnWP+fQnH9XEhD/Kljseo+lc47ueTjse11i/yjervVP9W
+/cyK32n/i+rfY55//lH7AHP+cRz/Q8z7euUfKd7Kx6rf4djPCY7+N4qfql6P
+1/vxDPN9q/i5+s1a70L1B61/iXnfh+P79ErzJ9W71vpF+TfK32m9W8Vn1btT
+vUXz7zU//bPu7wDzPgDH/eUQ8/2Ao/6R4i2Ofo41v1P8RPGN+jlVP718pvyt
+6p/LWfUvlD8ofimPON4XXKn+JF/LRevdYO7nWu9Wnh+8/7uTF/V3r/z0fr3e
+wfv1/JV8KDfyEY6/9sH78VjzO8VP5I18qvq94mfaz1bxczmr3oX6G+RLzR/l
+K82fFL9WvCh+I+/kW3mW7+RFvpfTv2ofyCv5UG7kI7mVj+VOPpE38qncy2eY
+f29Q/FzO8oXyB/lSHpV/9eD9OGn+teYX+Ubzd4rfyrPm3+G4/hf1cy+nD+r8
+gw/q+Apz/1e8Uf6R4q18LHfKP5E3mn+Keb+k/s7kreqdy1n1LnB8fw2KX8qj
+1rtSv5PWu1a8yDeqv5Nv5Vn5d5jfO4rfq9/077reAeZ9OOb+j/n3Wszzn9yq
+3rHyO/kEc/+XTzW/x/F8eqb9bLX+ufKz6l8of1D+pfY34nievcLxPDlhnv+0
+flH9G8V38q3mz/Kd+lsUv1d/6cM6foB5H/xhPf8Q8/sPr/fjEeb5X/nHqt/h
+OH8nmPdJyj9VvMfxvH+GH+n+C6QmaUw=
+             "]]}, {
+            Hue[0.6142719099991583, 0.6, 0.6], 
+            Directive[
+             PointSize[0.002777777777777778], 
+             AbsoluteThickness[1.6], 
+             RGBColor[0.762631, 0.846998, 0.914031]], 
+            LineBox[CompressedData["
+1:eJx12jlw9VYZh3ENlctbULigEB6G8TAMI3azRmzB7CJsJmwiIcFsiQIBTEiI
+2F3e0qVKl7d0qdKlSpcq3TBzS5fA+P98zHlmcJEzv+895z2rZEnO2597+ZkX
+3lJV1b/+85//lo8/+6eq8qcty4OUG5XE35qyTnmY8p0p36Z/r1UepXyHyncp
+z7tTHqv8f/X49/eov0b9vFf136d875c/oH4+qPF8KCXz/nBK1ulE8Y+kZH0+
+qvjHNP6Pax6fkD+Zknk9JbcpM68RM69Ppcw6jJh5frr0iFmnz5T9jZh1+az6
+x6z/51JmvUfMvjxd5hufVvzzKbMeI2b/TlNmv0a5+kLK7O+Iyf/Fcrwjpv2X
+UubcjZj9+XLK7NOIOSdfSZlzMWLOxVcVx7T/mvJj2ncps98tZj9w5jtjzs/X
+y/otTv8jzvxnzPl6poy38oizXjPmfHyjjLc4+UdM/3L1TfWPaY9zvma5+lbK
+zLeVR5zrY8ZcH98u+2sx7RWfMdffd8rxtJj2is+KV2cpcx9pMdc7znmZMfet
+76p/zPmRZ8z182w5nvbZsv6Imb/i1fdSZj1azPzlGbN/3y/ztzjzG+UZc5/+
+gfrH3O8w48ecvx+W9VvM/HHuJzPm+vlRGW8x7XHyz5j178t8NWY/Fe8x91Oc
+/BPmfoGzPqvyVz8u69eY9VC8x1yfOPeDSfEZp79V+arnUmY/apx8rdxjfh/h
+rMekfLO8Yu6fz6fM+tRy+3xZv8f8vsIZz4TzfDDjPN+smPvnT1Lm91uNsz4t
+pn95xMwfH6V/nP5WzO/fF1Ky/pjzrHiPOX+KTzj9zTjzWZW/erHMV79Y1m8V
+7+VRnjDXG876rvgo5U/VP+Z+hHMeesVHzPWHud9i5o95Xj1Pmf2oMedf7jHn
+D+d5dlK+GR+lf8zz68/KfDXOeW1x2vc47UfM9a/4jFl/zP3356VrzPnDef7u
+Mf0rPuG8F804z/Mr5n3jFymP0j/OerY47Xuc/kbFJ5z3tFleVb/6ZdlfjTOe
+Vu4x88f0j9l/zP1H+apflfOpcfK1OP31OO1HxSe1n3H2Y5Wrl1JmfeqXyngr
+9/Ko9pM847wfr4pXL5fx+uUy3ireyyPOe/uk+Kz4qvzVUNbfyDXOfBvM+cTJ
+16l+Lw/KPyq+lSd5p/5mxRfFV/W3l6tXyvqbV8p4rXgjt3Kn9j3O+g/y+KT+
+489WnuSdPMuL8q+K7+Xq16U3OO1rxZsnfixb1e8U7+VB9Ufl38qTvJNn5V8w
++6/6e7n6Tdl+g7kfKN4o3uKcv07uVX/AzF/eypO8k2d5UX+rvNd8qlfL+ObV
+Ml7LDU5/reKd4v2T+OPPoPqj6m8VnxTfybO8qP2q+B5z//9tyvy+2Mi13GDu
+f/josexwft/1ig/KN8pbecLc/xSf5UXjWzH7L1e/K73B7L/cqH6LOf+K9zjj
+G+RR7bfyhPN8sMOZ3ywv+OixXHH2Y6/+q9+X9TeY52G5Uf1W7jDvKzjP94M8
+ylu1n3Ceb3eqP+O8HyyKr8q3V77qooxv5BrnebjBWY8WZ386te9xnr8HzPsj
+Zv7yhJm/PKu/Re1XnPehveLVH8rxbeQap32DeT/CmU+H+V6ifANm/5V/q/YT
+zvvbDvM9UfkWjWdV/b3i1Wsps78bnPnVr5X1G8z3XrnDfK9R+0HxUfGt+p9w
+9neHs54zznlcFF+Vb6949ceUWb8N5nsUZv8x36fUvsOcf5z1H5R/VL6t2k+K
+7zDft5RvUX+rxr9X++r1lPk+tsH5vlm/XtZvMN9HMPuv+j1m/zHfZ1V/i/O9
+ecL5/rrTeGe1XzSeFWd/9pj9fyMl9783yvo1zvlpcNq3at/JvfINmO838lb1
+J5zfXzvln1V/wXzvVHyP+X7+pzK+kWuc+TaKt4p3co9zXgbM33dwzutW9Sec
+63uHuf/jnK9FXjHnH/P3izdTcv4x1/+bZf1G8RZn/B3O32l7nPM+4JzvEed6
+26q/SePbqf8Zs/8467Vi7n+Y639MmfU6wFmvjXyIWR+cfMc4421w5nuCM98W
+5+/Opzh/p+5w1uMMZz179Xeu+oP6u8D8vVrju5S3qn+l+U845/0ac71q/W60
+XrPitxr/It+p/YpzPd3Le/lB61X9OWXOzwHmeQBnfoeqX2P2H2d9Gpzzd6L8
+reqfqn4nn2k8Pc75PceZ76D8F5j3D/kS5/rZarxXGs+Es9/XmPcVnPeTG8z3
+afV3Ky+a7x0+eixXje9e8b3G96B49ZcyfoB5HsZZz0Oc8ddqf4wz/wanvxPF
+W5z1P5U7+Uz99/K58g+KXyjfKF+q/Vbtr1R/wnlfvZZ38o0847xf3yr/ov7v
+NL5V8Xu136u/B8z/5/XXsv8DzPcA+RDz9wL5GPO9WO1P5FY+VftO8TPFe8XP
+5UHzu8B8f5Mv5a18JU9P8j/+XMs79X8jz/Ktxr/Id/Kq9vca317jeZCrv5U+
+kDfyoVzLx3Ijn8itfCp38pncy+fyIF/Io3wpb+UrzP7L1/LuSfvH8kb5ZvlW
+XpTvTvFV8Xv1t8c5Lw+Y719/L32Acz1vcPIdYr6PK36seKP4Cebva+r/VPFO
+PlO+Xv2dq/6g/BfyKF9i7v/yFebvjZjf//josdyp/Y3az+r/Vl7U/k5ele9e
+8b3G86D81T9SZv0OcNZvg5PvUPEac//HfC9X+xPFW/kUZz4dzvPQGeb7uvKf
+Y57/cJ6PLpR/VPtL5d+q/pXik8Z/rfhO+W9Uf9Z63qq/BR89lneKr1r/e+Xf
+yw9y9c+UWZ8DnPXeyIdyjfO8eIzzftDgvB+cYL4fYp7/Md9Tcd6/zpSvx3kf
+PP9f/X8DpGN2SA==
+             "]]}, {
+            Hue[0.8503398874989481, 0.6, 0.6], 
+            Directive[
+             PointSize[0.002777777777777778], 
+             AbsoluteThickness[1.6], 
+             RGBColor[0.8519034999999999, 0.876768, 0.874037]], 
+            LineBox[CompressedData["
+1:eJxd2jls9VgZh3GLKuUtKFJQmAihaISQhzWsY9YJy4AZYAi7+YaBwAx8lz3s
+hmFJecuULlPeMqXLlC5TukyD5DIloPyfTzrPV8zRL+8571mvr+07b3/y9OXX
+3lJV1X/+95//l4//1hceyxfa/CHl+1IepHw+5Sblccq3yocpj1K+Ta5ll+9Q
+vncqfqx6z+nv75LfrTyN2j2vv79H/b1X9VkX8r9f/X5A/X1QPtG4PqS8H9a4
+PqK8H9V4P6Zxf1xmX8nXpsy8Bkz/nyg9YPr7ZMqsx4CZ/6dKD5jxfFrtMfv5
+mbK/AdP+s6UHzPq8mJL5vVjWr05TZl0GzLp+LmXWdcDsy+dTZt8GTP9fKD3I
+1RdT5hwMmHP0Usqcm+Elxb+UkvXBnKcvlx4w+9ulzPq0nerj5J8w6/eV0q08
+4OSfMON/uXSLWW95wuzPV0u38oCzfhNm/b9WxlvMeVB8kquvqz3O53TAWe8J
+s36vlONpXynjA2b9Mdehb6TM+Wkx5w3nfE6Y9mfqH9M/zv5Mql99M2Xm12L2
+D2d8E+Y6962U+Ty1mPOu+IS5Dn47JfuPM94B53o3YT4f3ynjrTzgzHfCXGe/
+m5LPD+Z6h9k/zPn5XjmfFnM9wZnfhFn/75ducdZrwKw/pv++bF/jrE+LM59e
+HnC+/0bMfHHOx4I5fz8ox1Njridyj9kfnPGO8oRzHha5elKOr35Sxlu5x/SP
+sx4jznpM8oI5f6+mzPddjfN92L5a1u8x38c4+z1izivO+i3qr/phOf5abnHG
+38uD6o849zeTvOCjlK+V8RrzecJZjx5z/nD2Z1R8wtmvRa5+lDLntcacf8V7
+zPxx1nPEuc+d5AVz//fj0jVO/lbuMfdLmPVX/QnnPnvB3Iefl/FabnHu63uc
++/4BH6V/nPv+SV6Uv/qJ+pdbnPY9znoNmOsPzn5Mar/I1U9L1zjzaXHG02Pm
+L4+qPyn/gln/19X/62W8xcnfKz5gzp/ik/IvildvqH+c/to3yvq96g8452NU
+fFK+RfHqZ2X7Guc5s8V5Du0x6y+Paj8pvqi/6udl/lpu5R4n/yCPOM/Rk9ov
+ql89LV0/Leu3OPl6eVD7EWe+k+KLXG3L/jY4+WvFG8z+PIs//uvkXt4q/yDv
+5FHt9/Ikz/Iir3L1i9IbuZYbuZU7uZe38oCZvzyq/l6eVH+WF3lV++qXpTeY
+/ZebZ/Ufy1bxTvEe57xsMZ9fxXdqPyr/XvFJnpV/UXyVq1+V3si13GDOP871
+vsN8X+KMZysP8k4e5b36n+RZXtR+latfl/PbYK5HijeY7wfV7xTvcdZjKw84
+3wc7xUfF94pPOOs/43wfLjjfX6vyVb8pvcHMH2c+Deb7We6Ur1d8Kw/46LHc
+Yb7PFd9j7q8Vn3HWZ1F/q1z9tvQGcz+meIMzv1bu5F7tt8o/4Ny/7jD3czj3
+63vVn+QZ5/54wVmvFR+l/F1Zf4Nz/1/Ljeq3OPk7zPMqzvPDFvP8gjPfHc58
+R5znob08qf6s/haNZ1X76qJsv8GZX43zPNlgns/kTu17zPwx81f+Hc54R9Xf
+Y97Hqf9Z81lw1neVq9+X9TeY9wE472MaxVu17xTvcea3xbxflXfyiJk/5n0c
+zvrO6m+RV7Wv/lC232Dmj/P+qMG8n8HsP+Z9BU5/W8z7E9XfySPOedqr/0nj
+m3HOx4Lzvm7VeKs/lvk2OOOrcfI1OOehxVnfDid/jzn/yj+o/g7zPkPt95j3
+yRrfrPyL8q0ab/WnMr7B7D/O+jeY/Zc7ucecf8zvHep/p/5HzPwx73Mxn3+c
+87Mo36r61Z/L+AZn/LXiDeZ9K858OrmXtzi/sw2K79TfiHPe9opP8ox536n4
+ivn97i8pOf9yLTeY9+U419NO7lV/i9l/nPHtcMY3qv895vsPZ31mzPxVf1W+
+6q/leDaY94E4428w51/uMNd/nOv3VvkG9bdT/RHz/a/+JuWblW/BfP7VvhpS
+5vpxgPk84OQ/xLwvxtnvY8Ub+URu1f5U7nA+z2dyL5/jXK+26u9C8xlw1udS
+899pfa5Uf1T9a+Xfq/8becLZr1uc+/8Z5/7yTvNbVP9e+Ve1f8BHKf+WMut9
+gJNvIx9i3lfj3N8fYz4van+i+i3O88Apzvg69Xem9r3an8tb9X+BeX+u+CXm
+eVTjuVL+Uet3rXx7+Uae5Fv1N2u+d/Ki8dyr/ar5PKh+9fcy3wFO+w3O8+8h
+5vlQ7Y/lBud59ATz/Kj6p6rfyWdq38vnqr+VL1R/UPwS8z4G533AleqPil8r
+vlf8BvP7gMZzq/5ntb9T/gXn/cy96q/K96B49WbZ/uDNMr5R/BAnXy0f44yv
+UfsTuZVPla+Tz1S/l8/lrXyh+Q3y5bP6j/92OO8fr+RRvlb7vXwjT/KtPMt3
+8iLfy6v8IFf/KH0gb+RDuZaP5QZnfU7kVvVPFe+exR/LM9XvVf9c9beKX2D2
+X/ku5Z18pXyj+ruW9+rvRp5U/1bxGef832E+/2p/r/Gtyveg+tU/Sx/g9LeR
+DzG/F8rHqt9grv+Kt2p/inmfKp8pX6985/JW9S8w+6/4pfrbyVeY73/Fr9X/
+Xr5RfxM+eixvlX+W7+RFvpdXre+D4tW/yv4PcO63Npj7P8z+Y67/ijfyCeb3
+ffkUs/+Kn2m8Pc7917nab9X+Qh40vkvNf6f5X6n9qPFcK75XvhvVn1T/Fud8
+zIrfYe7/Nf97nPvvFef56EH1q3+X4zvA3P/jPE8cyrV8jPM80+A8H51g/v8W
+tT/FPE+r/hnm/Zran+Pn2v8C5zlxsA==
+             "]]}, {
+            Hue[0.08640786499873876, 0.6, 0.6], 
+            Directive[
+             PointSize[0.002777777777777778], 
+             AbsoluteThickness[1.6], 
+             RGBColor[0.941176, 0.906538, 0.834043]], 
+            LineBox[CompressedData["
+1:eJx12jlwLFcVgOEuIoUdECggaKYoSkVR1LCL1dcGg4xZmscmszaGZw+LeYPx
+IjZzwWAUdqiwQ4UTKuxQYYcKO1RCVYcKgZrzD3X/KiZ4tz6dc89deplW6733
+xSePHr+rqqp//eef/7b7z/LUvq1T/CDaI7X/L+/dqfz5sX7+HuU3iq8Uf5/8
+fs3jRPP5gOIf1Dw+JK/lD6veRzT+R1X/Y4p/PFrW/wnFPymfqt6nomWdn46W
+/fmM5vtZ9f+c4p+Xn4qW45DK+WRMvaejjeOUn1b8GcXxKtovlONlzHq+WOZn
+zHnxbDn//KziX9L8Mfv/5XK8jNmPM8Xl6rmyXn5O8a+oP2Z/n482zuP8vOJf
+jTaOd8araL+mOGb8r5fryZjr5huKY45fG21cRwlzvHD0H+Xqm+V8kpxxXHcj
+5vg9KuebHpXxjBkfc91/K9rYn4TZbxz1Rsz+f7t0wqvoL4/Kr76j+WOOlzzi
+qFd9N9pYX8KcbzjWO2Luc9+LNtaXMOvHcR8cMft3XtZLcsZxPEfM/F8o4wlz
+/rxQ5o+Y8+f7ZX7CnD+Y/VN+9YNoY78SjvVmzPmDWf8Py/klzP5hzh+5+lE5
+XsL0x4yPuX5/HG1cj0nOmPEx97eflPGEud7lEdO/K+ONnHDMt8OsD6/27YDj
++Iw41jPL1U/L/AZzPWHGxzFeVv9B+SOO9c6qX71Y5jdykjvM+a34II/yjNn/
+n5VucDx/JMU7OeNVjI/Zf8z4cvVzjY85H+UO832L43wZMOOr/4wZ/3FZr8Fc
+z4/L/A5zfmOOP47jO+K4f8zqX71U5jeY6wkzPub6xHG8BsVHzPmn+tXL5Xya
+l8v8hGN9neJZ/Qd5xOy/4tWmjDdywpx/imfM/uM4niOO/ZlVr/pFmd9grj/M
++jHPB5j1Y/Zf9eeD4/PL0o2cMOuX8yE/xsex3lGe5epXpRvM/iveyRnHfAbM
+/Qez/oPj8+tyvAZz/5E7Oav/gOMzKj4f4tG+Us6/eaXMT4p3imccn+HgfTti
+9l/x6jdlvMFkyZ3ys+LDwTG+4rP6V080/pMyPyneyVke5BFz/1G82oZjP+tt
+GW9wfNZyOnjftnKnels5y73qD/JO+aPik+KzvCi/+m3pWm7ktZzkVu7krZzl
+Xh7knTzKkzzLC+b4v1q6frXMbxRfK54UbxXv5K2c5V4e5J08ypM8y4tc/a50
+LTeY9R/i+zYpv1V+p/hW/bPivfoPyt8pPsqTPMuL6lWvlePXr5XxBrN+5Scc
+949W+Z28Vf8s9xp/UP2d6o3yJM+qtyhevV66fr3MbxRfK54UbxXvFN/KWfn9
+wfvPgFm/4qPqTcqfVX9RfvVGWa9+o4w3OJ4n1of8fZuU32J+X1D9replHN9P
+veKDxtspPio+ybPGX9S/erPMr98s4w2O+a3lJLdyp3pbxbPcK3/A8fy7w7wP
+wPH8O6neLC/Kry7K+vVFGW8w61d+Un6LV/u2U3yrehnHent5UP8d5vle9SYc
++zOr3iJXvy/r1ZjrH7N+zPsR9W8V7xTfYt6fKL/H/D6l+E4e8WrfTorPOPZj
+waz/D2V+jVk/jvmv5YRjvq3inbzFHH8c8+s1n0HeyaP6T4rPmOMvV38s51Pj
+1b5tcKxvjTn+ON4ntjjeN3SY9WPuf3Kv8QeNt1P+qPlNWs+M+f7HvH/4U7Tc
+/zDv4+Q15vdzzP1P+R2O8bbKzziuh17xAbN+xUfNZ1L+rPEX5Vd/LuM1Xu3b
+BrN+OeGYf4vjfOgw9z85q14vD5rfDsf7+VHxSZ7lBfP+9a1yPvVbZX6j+Bpz
+/WOuf8z3n/pvFc9yj7n/49jfneKjxp80/1lelF/9pRy/xrG/DY7+a8z1j1m/
+3GG+/zHvL5Tfq/6g+e1Ub1S9SfFZ9RbVq3K5viPM8wBe7dtj5Tc4js+J+q9x
+jHeK+XsdjvmfqX6reueKdzjWu9F4W/W/wFx/qneper36Xyl/0P5cK75T/xvN
+b9R4t5rfpPp3qjdrvHt5Uf0H1a/+WvoIc/xxzPcY83ys/BN5jWP+p+qf5DPM
+8xSO9Zwrv8Px/bXRfLfyheaX1f9S+b18pfkN2r9r5e8Uv9H8R/lW9SfVu1O9
+Gcf3+73Wt2h9D+pf/a0c7wjHfGrM8Ve8UfwEx3hr5Z8qP8lnym/lc823kzeY
+37flCzlrvpeK96p/JQ+a37W8k28w17/q3Wo+08H7z508y/eY5z35QfWrt8v+
+R2+X8RpH/2PlN4qfyGv5VE4a70zxVuOdy528kbeqdyFn+VLuVe9KHjT/a/Xf
+yTfqPyp+q/gk38mzfK96i+IPcvX30kdyLR/LjXwir+VTOclnciufY94vKr6R
+t/KFnOVLudd4V4oP8rW8O3jf3ig+qv6t4pPid5j3e8q/lxf1f5Crf5Q+wvGp
+FT9WvDl4354ovlb8VPGk+mfKb+VzzP1f3qjeVuNdKJ7lS7mXr1RvkK8x3/+a
+/43mO8q3Gm9S/E71ZsXvNf6i/Ae5eifa+H46wrwPf6fMP8b8vVb9T+S1fKr+
+CcfzypnyW41/rnin+AbzvkXrucD8/wHlXx7q7T+94lcaf1D8Wv13Gv8G8/5K
+/W+1nkn7daf4LN9rvEXjPWj+1T9LH8m1fCw38gnmfSnm+sf8/xoc8ztT/xbz
++x/m+lf/zf/i/wa74W4A
+             "]]}}}, {}, {}, {{}, {}}, {{}, {}}}, {
+        DisplayFunction -> Identity, PlotRangePadding -> {{
+            Scaled[0.02], 
+            Scaled[0.02]}, {0, 0}}, AxesOrigin -> {0., 0}, 
+         PlotRange -> {{0., 749.}, {0, 50}}, PlotRangeClipping -> True, 
+         ImagePadding -> All, DisplayFunction -> Identity, AspectRatio -> 
+         NCache[GoldenRatio^(-1), 0.6180339887498948], Axes -> {True, True}, 
+         AxesLabel -> {None, None}, AxesOrigin -> {0., 0}, DisplayFunction :> 
+         Identity, Frame -> {{True, True}, {True, True}}, 
+         FrameLabel -> {{None, None}, {None, None}}, FrameStyle -> Directive[
+           GrayLevel[0.5], 
+           Thickness[Large]], 
+         FrameTicks -> {{Automatic, Automatic}, {Automatic, Automatic}}, 
+         GridLines -> {Automatic, Automatic}, GridLinesStyle -> Directive[
+           GrayLevel[0.5, 0.4]], ImageSize -> 750, 
+         Method -> {"CoordinatesToolOptions" -> {"DisplayFunction" -> ({
+               (Identity[#]& )[
+                Part[#, 1]], 
+               (Identity[#]& )[
+                Part[#, 2]]}& ), "CopiedValueFunction" -> ({
+               (Identity[#]& )[
+                Part[#, 1]], 
+               (Identity[#]& )[
+                Part[#, 2]]}& )}}, PlotRange -> {{0., 749.}, {0, 50}}, 
+         PlotRangeClipping -> True, PlotRangePadding -> {{
+            Scaled[0.02], 
+            Scaled[0.02]}, {0, 0}}, Ticks -> {Automatic, Automatic}}],FormBox[
+       
+        FormBox[
+         TemplateBox[{
+          "\"F\"", "\"B\"", "\"R\"", "\"L\"", "\"O\"", "\"M\"", "\"S\""}, 
+          "LineLegend", DisplayFunction -> (FormBox[
+            StyleBox[
+             StyleBox[
+              PaneBox[
+               TagBox[
+                GridBox[{{
+                   TagBox[
+                    GridBox[{{
                     GraphicsBox[{{
                     Directive[
                     EdgeForm[
@@ -1282,31 +1165,31 @@ QvVu5DXm/Cteqt5GrjR/q3j94MtnJzfqdye38l7u1O8g9+p31PxB+Sflj/K9
                     AspectRatio -> Full, ImageSize -> {20, 10}, 
                     PlotRangePadding -> None, ImagePadding -> Automatic, 
                     BaselinePosition -> (Scaled[0.1] -> Baseline)], #7}}, 
-                   GridBoxAlignment -> {
+                    GridBoxAlignment -> {
                     "Columns" -> {Center, Left}, "Rows" -> {{Baseline}}}, 
-                   AutoDelete -> False, 
-                   GridBoxDividers -> {
+                    AutoDelete -> False, 
+                    GridBoxDividers -> {
                     "Columns" -> {{False}}, "Rows" -> {{False}}}, 
-                   GridBoxItemSize -> {
+                    GridBoxItemSize -> {
                     "Columns" -> {{All}}, "Rows" -> {{All}}}, 
-                   GridBoxSpacings -> {
+                    GridBoxSpacings -> {
                     "Columns" -> {{0.5}}, "Rows" -> {{0.8}}}], "Grid"]}}, 
-               GridBoxAlignment -> {"Columns" -> {{Left}}, "Rows" -> {{Top}}},
-                AutoDelete -> False, 
-               GridBoxItemSize -> {
-                "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
-               GridBoxSpacings -> {"Columns" -> {{1}}, "Rows" -> {{0}}}], 
-              "Grid"], Alignment -> Left, AppearanceElements -> None, 
-             ImageMargins -> {{5, 5}, {5, 5}}, ImageSizeAction -> 
-             "ResizeToFit"], LineIndent -> 0, StripOnInput -> False], {
-           FontFamily -> "Arial"}, Background -> Automatic, StripOnInput -> 
-           False], TraditionalForm]& ), 
-        InterpretationFunction :> (RowBox[{"LineLegend", "[", 
-           RowBox[{
-             RowBox[{"{", 
-               RowBox[{
-                 RowBox[{"Directive", "[", 
-                   RowBox[{
+                 GridBoxAlignment -> {
+                  "Columns" -> {{Left}}, "Rows" -> {{Top}}}, AutoDelete -> 
+                 False, GridBoxItemSize -> {
+                  "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+                 GridBoxSpacings -> {"Columns" -> {{1}}, "Rows" -> {{0}}}], 
+                "Grid"], Alignment -> Left, AppearanceElements -> None, 
+               ImageMargins -> {{5, 5}, {5, 5}}, ImageSizeAction -> 
+               "ResizeToFit"], LineIndent -> 0, StripOnInput -> False], {
+             FontFamily -> "Arial"}, Background -> Automatic, StripOnInput -> 
+             False], TraditionalForm]& ), 
+          InterpretationFunction :> (RowBox[{"LineLegend", "[", 
+             RowBox[{
+               RowBox[{"{", 
+                 RowBox[{
+                   RowBox[{"Directive", "[", 
+                    RowBox[{
                     RowBox[{"PointSize", "[", "0.002777777777777778`", "]"}], 
                     ",", 
                     RowBox[{"AbsoluteThickness", "[", "1.6`", "]"}], ",", 
@@ -1324,8 +1207,7 @@ QvVu5DXm/Cteqt5GrjR/q3j94MtnJzfqdye38l7u1O8g9+p31PxB+Sflj/K9
                     RGBColor[
                     0.19561066666666668`, 0.0382696, 0.35294133333333333`], 
                     FrameTicks -> None, PlotRangePadding -> None, ImageSize -> 
-                    Dynamic[{
-                    Automatic, 1.35 CurrentValue["FontCapHeight"]/
+                    Dynamic[{Automatic, 1.35 CurrentValue["FontCapHeight"]/
                     AbsoluteCurrentValue[Magnification]}]], 
                     "RGBColor[0.293416, 0.0574044, 0.529412]"], Appearance -> 
                     None, BaseStyle -> {}, BaselinePosition -> Baseline, 
@@ -1349,8 +1231,8 @@ QvVu5DXm/Cteqt5GrjR/q3j94MtnJzfqdye38l7u1O8g9+p31PxB+Sflj/K9
                     Automatic, Method -> "Preemptive"], 
                     RGBColor[0.293416, 0.0574044, 0.529412], Editable -> 
                     False, Selectable -> False]}], "]"}], ",", 
-                 RowBox[{"Directive", "[", 
-                   RowBox[{
+                   RowBox[{"Directive", "[", 
+                    RowBox[{
                     RowBox[{"PointSize", "[", "0.002777777777777778`", "]"}], 
                     ",", 
                     RowBox[{"AbsoluteThickness", "[", "1.6`", "]"}], ",", 
@@ -1368,8 +1250,7 @@ QvVu5DXm/Cteqt5GrjR/q3j94MtnJzfqdye38l7u1O8g9+p31PxB+Sflj/K9
                     RGBColor[
                     0.2857456666666667, 0.1949898, 0.47963700000000004`], 
                     FrameTicks -> None, PlotRangePadding -> None, ImageSize -> 
-                    Dynamic[{
-                    Automatic, 1.35 CurrentValue["FontCapHeight"]/
+                    Dynamic[{Automatic, 1.35 CurrentValue["FontCapHeight"]/
                     AbsoluteCurrentValue[Magnification]}]], 
                     "RGBColor[0.4286185, 0.2924847, 0.7194555]"], Appearance -> 
                     None, BaseStyle -> {}, BaselinePosition -> Baseline, 
@@ -1393,8 +1274,8 @@ QvVu5DXm/Cteqt5GrjR/q3j94MtnJzfqdye38l7u1O8g9+p31PxB+Sflj/K9
                     Automatic, Method -> "Preemptive"], 
                     RGBColor[0.4286185, 0.2924847, 0.7194555], Editable -> 
                     False, Selectable -> False]}], "]"}], ",", 
-                 RowBox[{"Directive", "[", 
-                   RowBox[{
+                   RowBox[{"Directive", "[", 
+                    RowBox[{
                     RowBox[{"PointSize", "[", "0.002777777777777778`", "]"}], 
                     ",", 
                     RowBox[{"AbsoluteThickness", "[", "1.6`", "]"}], ",", 
@@ -1413,8 +1294,7 @@ QvVu5DXm/Cteqt5GrjR/q3j94MtnJzfqdye38l7u1O8g9+p31PxB+Sflj/K9
                     0.3758806666666667, 0.35170999999999997`, 
                     0.6063326666666666], FrameTicks -> None, PlotRangePadding -> 
                     None, ImageSize -> 
-                    Dynamic[{
-                    Automatic, 1.35 CurrentValue["FontCapHeight"]/
+                    Dynamic[{Automatic, 1.35 CurrentValue["FontCapHeight"]/
                     AbsoluteCurrentValue[Magnification]}]], 
                     "RGBColor[0.563821, 0.527565, 0.909499]"], Appearance -> 
                     None, BaseStyle -> {}, BaselinePosition -> Baseline, 
@@ -1438,8 +1318,8 @@ QvVu5DXm/Cteqt5GrjR/q3j94MtnJzfqdye38l7u1O8g9+p31PxB+Sflj/K9
                     Automatic, Method -> "Preemptive"], 
                     RGBColor[0.563821, 0.527565, 0.909499], Editable -> False,
                      Selectable -> False]}], "]"}], ",", 
-                 RowBox[{"Directive", "[", 
-                   RowBox[{
+                   RowBox[{"Directive", "[", 
+                    RowBox[{
                     RowBox[{"PointSize", "[", "0.002777777777777778`", "]"}], 
                     ",", 
                     RowBox[{"AbsoluteThickness", "[", "1.6`", "]"}], ",", 
@@ -1458,8 +1338,7 @@ QvVu5DXm/Cteqt5GrjR/q3j94MtnJzfqdye38l7u1O8g9+p31PxB+Sflj/K9
                     0.4421506666666667, 0.45818766666666666`, 
                     0.6078433333333333], FrameTicks -> None, PlotRangePadding -> 
                     None, ImageSize -> 
-                    Dynamic[{
-                    Automatic, 1.35 CurrentValue["FontCapHeight"]/
+                    Dynamic[{Automatic, 1.35 CurrentValue["FontCapHeight"]/
                     AbsoluteCurrentValue[Magnification]}]], 
                     "RGBColor[0.663226, 0.6872815, 0.9117649999999999]"], 
                     Appearance -> None, BaseStyle -> {}, BaselinePosition -> 
@@ -1483,8 +1362,8 @@ QvVu5DXm/Cteqt5GrjR/q3j94MtnJzfqdye38l7u1O8g9+p31PxB+Sflj/K9
                     Automatic, Method -> "Preemptive"], 
                     RGBColor[0.663226, 0.6872815, 0.9117649999999999], 
                     Editable -> False, Selectable -> False]}], "]"}], ",", 
-                 RowBox[{"Directive", "[", 
-                   RowBox[{
+                   RowBox[{"Directive", "[", 
+                    RowBox[{
                     RowBox[{"PointSize", "[", "0.002777777777777778`", "]"}], 
                     ",", 
                     RowBox[{"AbsoluteThickness", "[", "1.6`", "]"}], ",", 
@@ -1503,8 +1382,7 @@ QvVu5DXm/Cteqt5GrjR/q3j94MtnJzfqdye38l7u1O8g9+p31PxB+Sflj/K9
                     0.5084206666666666, 0.5646653333333334, 
                     0.6093540000000001], FrameTicks -> None, PlotRangePadding -> 
                     None, ImageSize -> 
-                    Dynamic[{
-                    Automatic, 1.35 CurrentValue["FontCapHeight"]/
+                    Dynamic[{Automatic, 1.35 CurrentValue["FontCapHeight"]/
                     AbsoluteCurrentValue[Magnification]}]], 
                     "RGBColor[0.762631, 0.846998, 0.914031]"], Appearance -> 
                     None, BaseStyle -> {}, BaselinePosition -> Baseline, 
@@ -1528,8 +1406,8 @@ QvVu5DXm/Cteqt5GrjR/q3j94MtnJzfqdye38l7u1O8g9+p31PxB+Sflj/K9
                     Automatic, Method -> "Preemptive"], 
                     RGBColor[0.762631, 0.846998, 0.914031], Editable -> False,
                      Selectable -> False]}], "]"}], ",", 
-                 RowBox[{"Directive", "[", 
-                   RowBox[{
+                   RowBox[{"Directive", "[", 
+                    RowBox[{
                     RowBox[{"PointSize", "[", "0.002777777777777778`", "]"}], 
                     ",", 
                     RowBox[{"AbsoluteThickness", "[", "1.6`", "]"}], ",", 
@@ -1544,11 +1422,10 @@ QvVu5DXm/Cteqt5GrjR/q3j94MtnJzfqdye38l7u1O8g9+p31PxB+Sflj/K9
                     RGBColor[0.8519034999999999, 0.876768, 0.874037], 
                     RectangleBox[{0, -1}, {2, 1}]}}, AspectRatio -> 1, Frame -> 
                     True, FrameStyle -> 
-                    RGBColor[
-                    0.5679356666666666, 0.584512, 0.5826913333333333], 
-                    FrameTicks -> None, PlotRangePadding -> None, ImageSize -> 
-                    Dynamic[{
-                    Automatic, 1.35 CurrentValue["FontCapHeight"]/
+                    RGBColor[0.5679356666666666, 0.584512, 
+                    0.5826913333333333], FrameTicks -> None, PlotRangePadding -> 
+                    None, ImageSize -> 
+                    Dynamic[{Automatic, 1.35 CurrentValue["FontCapHeight"]/
                     AbsoluteCurrentValue[Magnification]}]], 
                     "RGBColor[0.8519034999999999, 0.876768, 0.874037]"], 
                     Appearance -> None, BaseStyle -> {}, BaselinePosition -> 
@@ -1572,8 +1449,8 @@ QvVu5DXm/Cteqt5GrjR/q3j94MtnJzfqdye38l7u1O8g9+p31PxB+Sflj/K9
                     Automatic, Method -> "Preemptive"], 
                     RGBColor[0.8519034999999999, 0.876768, 0.874037], 
                     Editable -> False, Selectable -> False]}], "]"}], ",", 
-                 RowBox[{"Directive", "[", 
-                   RowBox[{
+                   RowBox[{"Directive", "[", 
+                    RowBox[{
                     RowBox[{"PointSize", "[", "0.002777777777777778`", "]"}], 
                     ",", 
                     RowBox[{"AbsoluteThickness", "[", "1.6`", "]"}], ",", 
@@ -1592,8 +1469,7 @@ QvVu5DXm/Cteqt5GrjR/q3j94MtnJzfqdye38l7u1O8g9+p31PxB+Sflj/K9
                     0.6274506666666667, 0.6043586666666667, 
                     0.5560286666666667], FrameTicks -> None, PlotRangePadding -> 
                     None, ImageSize -> 
-                    Dynamic[{
-                    Automatic, 1.35 CurrentValue["FontCapHeight"]/
+                    Dynamic[{Automatic, 1.35 CurrentValue["FontCapHeight"]/
                     AbsoluteCurrentValue[Magnification]}]], 
                     "RGBColor[0.941176, 0.906538, 0.834043]"], Appearance -> 
                     None, BaseStyle -> {}, BaselinePosition -> Baseline, 
@@ -1617,67 +1493,97 @@ QvVu5DXm/Cteqt5GrjR/q3j94MtnJzfqdye38l7u1O8g9+p31PxB+Sflj/K9
                     Automatic, Method -> "Preemptive"], 
                     RGBColor[0.941176, 0.906538, 0.834043], Editable -> False,
                      Selectable -> False]}], "]"}]}], "}"}], ",", 
-             RowBox[{"{", 
-               RowBox[{#, ",", #2, ",", #3, ",", #4, ",", #5, ",", #6, 
-                 ",", #7}], "}"}], ",", 
-             RowBox[{"LegendMarkers", "\[Rule]", 
-               RowBox[{"{", 
-                 RowBox[{
-                   RowBox[{"{", 
-                    RowBox[{"False", ",", "Automatic"}], "}"}], ",", 
-                   RowBox[{"{", 
-                    RowBox[{"False", ",", "Automatic"}], "}"}], ",", 
-                   RowBox[{"{", 
-                    RowBox[{"False", ",", "Automatic"}], "}"}], ",", 
-                   RowBox[{"{", 
-                    RowBox[{"False", ",", "Automatic"}], "}"}], ",", 
-                   RowBox[{"{", 
-                    RowBox[{"False", ",", "Automatic"}], "}"}], ",", 
-                   RowBox[{"{", 
-                    RowBox[{"False", ",", "Automatic"}], "}"}], ",", 
-                   RowBox[{"{", 
-                    RowBox[{"False", ",", "Automatic"}], "}"}]}], "}"}]}], 
-             ",", 
-             RowBox[{"Joined", "\[Rule]", 
                RowBox[{"{", 
                  
-                 RowBox[{
-                  "True", ",", "True", ",", "True", ",", "True", ",", "True", 
-                   ",", "True", ",", "True"}], "}"}]}], ",", 
-             RowBox[{"LabelStyle", "\[Rule]", 
-               RowBox[{"{", "}"}]}], ",", 
-             RowBox[{"LegendLayout", "\[Rule]", "\"Column\""}]}], "]"}]& ), 
-        Editable -> True], TraditionalForm], TraditionalForm]},
-    "Legended",
-    DisplayFunction->(GridBox[{{
-        TagBox[
-         ItemBox[
-          PaneBox[
-           TagBox[#, "SkipImageSizeLevel"], Alignment -> {Center, Baseline}, 
-           BaselinePosition -> Baseline], DefaultBaseStyle -> "Labeled"], 
-         "SkipImageSizeLevel"], 
-        ItemBox[#2, DefaultBaseStyle -> "LabeledLabel"]}}, 
-      GridBoxAlignment -> {"Columns" -> {{Center}}, "Rows" -> {{Center}}}, 
-      AutoDelete -> False, GridBoxItemSize -> Automatic, 
-      BaselinePosition -> {1, 1}]& ),
-    Editable->True,
-    InterpretationFunction->(RowBox[{"Legended", "[", 
-       RowBox[{#, ",", 
-         RowBox[{"Placed", "[", 
-           RowBox[{#2, ",", "After"}], "]"}]}], "]"}]& )]}], "}"}]], "Output",\
-
+                 RowBox[{#, ",", #2, ",", #3, ",", #4, ",", #5, ",", #6, 
+                   ",", #7}], "}"}], ",", 
+               RowBox[{"LegendMarkers", "\[Rule]", 
+                 RowBox[{"{", 
+                   RowBox[{
+                    RowBox[{"{", 
+                    RowBox[{"False", ",", "Automatic"}], "}"}], ",", 
+                    RowBox[{"{", 
+                    RowBox[{"False", ",", "Automatic"}], "}"}], ",", 
+                    RowBox[{"{", 
+                    RowBox[{"False", ",", "Automatic"}], "}"}], ",", 
+                    RowBox[{"{", 
+                    RowBox[{"False", ",", "Automatic"}], "}"}], ",", 
+                    RowBox[{"{", 
+                    RowBox[{"False", ",", "Automatic"}], "}"}], ",", 
+                    RowBox[{"{", 
+                    RowBox[{"False", ",", "Automatic"}], "}"}], ",", 
+                    RowBox[{"{", 
+                    RowBox[{"False", ",", "Automatic"}], "}"}]}], "}"}]}], 
+               ",", 
+               RowBox[{"Joined", "\[Rule]", 
+                 RowBox[{"{", 
+                   
+                   RowBox[{
+                    "True", ",", "True", ",", "True", ",", "True", ",", 
+                    "True", ",", "True", ",", "True"}], "}"}]}], ",", 
+               RowBox[{"LabelStyle", "\[Rule]", 
+                 RowBox[{"{", "}"}]}], ",", 
+               RowBox[{"LegendLayout", "\[Rule]", "\"Column\""}]}], "]"}]& ), 
+          Editable -> True], TraditionalForm], TraditionalForm]},
+      "Legended",
+      DisplayFunction->(GridBox[{{
+          TagBox[
+           ItemBox[
+            PaneBox[
+             TagBox[#, "SkipImageSizeLevel"], Alignment -> {Center, Baseline},
+              BaselinePosition -> Baseline], DefaultBaseStyle -> "Labeled"], 
+           "SkipImageSizeLevel"], 
+          ItemBox[#2, DefaultBaseStyle -> "LabeledLabel"]}}, 
+        GridBoxAlignment -> {"Columns" -> {{Center}}, "Rows" -> {{Center}}}, 
+        AutoDelete -> False, GridBoxItemSize -> Automatic, 
+        BaselinePosition -> {1, 1}]& ),
+      Editable->True,
+      InterpretationFunction->(RowBox[{"Legended", "[", 
+         RowBox[{#, ",", 
+           RowBox[{"Placed", "[", 
+             RowBox[{#2, ",", "After"}], "]"}]}], "]"}]& )]}
+   },
+   AutoDelete->False,
+   GridBoxItemSize->{"Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}],
+  "Grid"]], "Output",
  CellChangeTimes->{{3.721573196500379*^9, 3.721573238537655*^9}, {
-  3.721573331916349*^9, 3.7215733510775337`*^9}, {3.721573397411191*^9, 
-  3.7215734370257196`*^9}, {3.721573484508605*^9, 3.721573505445148*^9}, {
-  3.7215736419941893`*^9, 3.721573658306859*^9}, {3.721573731513576*^9, 
-  3.721573738369928*^9}, {3.7215738661302013`*^9, 3.721573872259843*^9}, {
-  3.721573902539761*^9, 
-  3.721573928333933*^9}},ExpressionUUID->"d67dfbb2-f39a-4172-85bf-\
-19f08e645771"]
+   3.721573331916349*^9, 3.7215733510775337`*^9}, {3.721573397411191*^9, 
+   3.7215734370257196`*^9}, {3.721573484508605*^9, 3.721573505445148*^9}, {
+   3.7215736419941893`*^9, 3.721573658306859*^9}, {3.721573731513576*^9, 
+   3.721573738369928*^9}, {3.7215738661302013`*^9, 3.721573872259843*^9}, {
+   3.721573902539761*^9, 3.721573928333933*^9}, 3.721574041152367*^9, 
+   3.721574075112591*^9, {3.721574112118052*^9, 3.721574133607483*^9}, {
+   3.721574163626666*^9, 3.721574213095039*^9}, 3.7215743493358593`*^9, 
+   3.721574470624791*^9, 3.7215745704506083`*^9, {3.721574778842506*^9, 
+   3.721574788142241*^9}, {3.721574933868631*^9, 3.721574946484189*^9}, {
+   3.721575080709552*^9, 3.721575110590807*^9}, {3.721575238443699*^9, 
+   3.7215752453027773`*^9}, 3.721575348719208*^9, 3.7215756494102*^9, 
+   3.721576857155864*^9, 3.721577802944447*^9, 
+   3.7215788755557003`*^9},ExpressionUUID->"697ac75f-f11e-485f-bc55-\
+46ce84d7c573"],
+
+Cell[BoxData["\<\"/Users/sanchez.hmsc/Documents/GitHub/MASH-Main/MASH-dev/\
+HectorSanchez/VectorControl/Debug/ATSBRepel.png\"\>"], "Output",
+ CellChangeTimes->{{3.721573196500379*^9, 3.721573238537655*^9}, {
+   3.721573331916349*^9, 3.7215733510775337`*^9}, {3.721573397411191*^9, 
+   3.7215734370257196`*^9}, {3.721573484508605*^9, 3.721573505445148*^9}, {
+   3.7215736419941893`*^9, 3.721573658306859*^9}, {3.721573731513576*^9, 
+   3.721573738369928*^9}, {3.7215738661302013`*^9, 3.721573872259843*^9}, {
+   3.721573902539761*^9, 3.721573928333933*^9}, 3.721574041152367*^9, 
+   3.721574075112591*^9, {3.721574112118052*^9, 3.721574133607483*^9}, {
+   3.721574163626666*^9, 3.721574213095039*^9}, 3.7215743493358593`*^9, 
+   3.721574470624791*^9, 3.7215745704506083`*^9, {3.721574778842506*^9, 
+   3.721574788142241*^9}, {3.721574933868631*^9, 3.721574946484189*^9}, {
+   3.721575080709552*^9, 3.721575110590807*^9}, {3.721575238443699*^9, 
+   3.7215752453027773`*^9}, 3.721575348719208*^9, 3.7215756494102*^9, 
+   3.721576857155864*^9, 3.721577802944447*^9, 
+   3.721578882123568*^9},ExpressionUUID->"211a43f7-1510-453c-9ca0-\
+d55fee8b5cd7"]
 }, Open  ]]
 },
-WindowSize->{2178, 1260},
+WindowSize->{1712, 1367},
 WindowMargins->{{0, Automatic}, {Automatic, 0}},
+Magnification:>0.75 Inherited,
 FrontEndVersion->"11.1 for Mac OS X x86 (32-bit, 64-bit Kernel) (April 27, \
 2017)",
 StyleDefinitions->"Default.nb"
@@ -1694,10 +1600,12 @@ CellTagsIndex->{}
 (*NotebookFileOutline
 Notebook[{
 Cell[CellGroupData[{
-Cell[580, 22, 4081, 105, 348, "Input", "ExpressionUUID" -> \
+Cell[580, 22, 4567, 124, 315, "Input", "ExpressionUUID" -> \
 "6e6e83fe-a091-422f-89b0-b762b3bb1c02"],
-Cell[4664, 129, 82653, 1546, 489, "Output", "ExpressionUUID" -> \
-"d67dfbb2-f39a-4172-85bf-19f08e645771"]
+Cell[5150, 148, 75317, 1414, 733, "Output", "ExpressionUUID" -> \
+"697ac75f-f11e-485f-bc55-46ce84d7c573"],
+Cell[80470, 1564, 1145, 16, 27, "Output", "ExpressionUUID" -> \
+"211a43f7-1510-453c-9ca0-d55fee8b5cd7"]
 }, Open  ]]
 }
 ]

--- a/MASH-dev/HectorSanchez/VectorControl/PopCountsDebugger.nb
+++ b/MASH-dev/HectorSanchez/VectorControl/PopCountsDebugger.nb
@@ -1,0 +1,1705 @@
+(* Content-type: application/vnd.wolfram.mathematica *)
+
+(*** Wolfram Notebook File ***)
+(* http://www.wolfram.com/nb *)
+
+(* CreatedBy='Mathematica 11.1' *)
+
+(*CacheID: 234*)
+(* Internal cache information:
+NotebookFileLineBreakTest
+NotebookFileLineBreakTest
+NotebookDataPosition[       158,          7]
+NotebookDataLength[     87789,       1697]
+NotebookOptionsPosition[     87333,       1678]
+NotebookOutlinePosition[     87688,       1694]
+CellTagsIndexPosition[     87645,       1691]
+WindowFrame->Normal*)
+
+(* Beginning of Notebook Content *)
+Notebook[{
+
+Cell[CellGroupData[{
+Cell[BoxData[
+ RowBox[{
+  RowBox[{"(*", 
+   RowBox[{"Import", " ", "and", " ", "Setup", " ", "Data"}], "*)"}], 
+  "\[IndentingNewLine]", 
+  RowBox[{
+   RowBox[{
+    RowBox[{"folder", "=", 
+     RowBox[{
+      RowBox[{"NotebookDirectory", "[", "]"}], "<>", 
+      "\"\<Debug/Mosquito/\>\""}]}], ";"}], "\[IndentingNewLine]", 
+   RowBox[{
+    RowBox[{"raw", "=", 
+     RowBox[{
+      RowBox[{"{", 
+       RowBox[{"mRaw", ",", "fRaw"}], "}"}], "=", 
+      RowBox[{
+       RowBox[{
+        RowBox[{"Import", "[", 
+         RowBox[{"(", 
+          RowBox[{"folder", "<>", "#"}], ")"}], "]"}], "&"}], "/@", 
+       RowBox[{"{", 
+        RowBox[{
+        "\"\<MaleMosquitoPop_Run1.csv\>\"", ",", 
+         "\"\<FemaleMosquitoPop_Run1.csv\>\""}], "}"}]}]}]}], ";"}], 
+   "\[IndentingNewLine]", 
+   RowBox[{
+    RowBox[{"head", "=", 
+     RowBox[{
+      RowBox[{"{", 
+       RowBox[{"mHead", ",", "fHead"}], "}"}], "=", 
+      RowBox[{
+       RowBox[{
+        RowBox[{"(", 
+         RowBox[{"#", "[", 
+          RowBox[{"[", 
+           RowBox[{"1", ",", 
+            RowBox[{"2", ";;", "All"}]}], "]"}], "]"}], ")"}], "&"}], "/@", 
+       RowBox[{"{", 
+        RowBox[{"mRaw", ",", "fRaw"}], "}"}]}]}]}], ";"}], 
+   "\[IndentingNewLine]", 
+   RowBox[{
+    RowBox[{"data", "=", 
+     RowBox[{
+      RowBox[{"{", 
+       RowBox[{"mData", ",", "fData"}], "}"}], "=", 
+      RowBox[{
+       RowBox[{
+        RowBox[{"(", 
+         RowBox[{"#", "[", 
+          RowBox[{"[", 
+           RowBox[{
+            RowBox[{"2", ";;", "All"}], ",", 
+            RowBox[{"2", ";;", "All"}]}], "]"}], "]"}], ")"}], "&"}], "/@", 
+       RowBox[{"{", 
+        RowBox[{"mRaw", ",", "fRaw"}], "}"}]}]}]}], ";"}], 
+   "\[IndentingNewLine]", 
+   RowBox[{"(*", "*)"}], "\[IndentingNewLine]", 
+   RowBox[{
+    RowBox[{"plots", "=", 
+     RowBox[{
+      RowBox[{
+       RowBox[{"ListLinePlot", "[", 
+        RowBox[{
+         RowBox[{
+          RowBox[{"#", "[", 
+           RowBox[{"[", "1", "]"}], "]"}], "//", "Transpose"}], ",", 
+         "\[IndentingNewLine]", 
+         RowBox[{"PlotRange", "\[Rule]", 
+          RowBox[{"{", 
+           RowBox[{"0", ",", "All"}], "}"}]}], ",", "\[IndentingNewLine]", 
+         RowBox[{"Frame", "\[Rule]", "True"}], ",", "\[IndentingNewLine]", 
+         RowBox[{"FrameStyle", "\[Rule]", 
+          RowBox[{"Directive", "[", 
+           RowBox[{"Gray", ",", "Thick"}], "]"}]}], ",", 
+         "\[IndentingNewLine]", 
+         RowBox[{"GridLines", "\[Rule]", "Automatic"}], ",", 
+         "\[IndentingNewLine]", 
+         RowBox[{"PlotLegends", "\[Rule]", 
+          RowBox[{"#", "[", 
+           RowBox[{"[", "2", "]"}], "]"}]}], ",", "\[IndentingNewLine]", 
+         RowBox[{"PlotStyle", "\[Rule]", "\"\<LakeColors\>\""}], ",", 
+         "\[IndentingNewLine]", 
+         RowBox[{"ImageSize", "\[Rule]", "750"}]}], "\[IndentingNewLine]", 
+        "]"}], "&"}], "/@", 
+      RowBox[{"Transpose", "[", 
+       RowBox[{"{", 
+        RowBox[{"data", ",", "head"}], "}"}], "]"}]}]}], ";"}], 
+   "\[IndentingNewLine]", 
+   RowBox[{"Grid", "[", 
+    RowBox[{"{", 
+     RowBox[{"{", "}"}], "}"}], "]"}]}]}]], "Input",
+ CellChangeTimes->{{3.721571945747401*^9, 3.7215719990110617`*^9}, {
+  3.72157204332439*^9, 3.721572106483636*^9}, {3.7215723999086027`*^9, 
+  3.7215724005084047`*^9}, {3.721572449629941*^9, 3.721572503515877*^9}, {
+  3.7215726378940973`*^9, 3.721572666649776*^9}, {3.721572712938615*^9, 
+  3.721572719485774*^9}, {3.721572760952183*^9, 3.721572790830947*^9}, {
+  3.721572852454445*^9, 3.721572917186318*^9}, {3.7215729473160887`*^9, 
+  3.7215729921324244`*^9}, {3.7215730785823708`*^9, 3.7215731056223783`*^9}, {
+  3.721573140145677*^9, 3.721573238165457*^9}, {3.721573326650441*^9, 
+  3.7215733506455727`*^9}, {3.721573390115328*^9, 3.7215734363921824`*^9}, {
+  3.7215734786963253`*^9, 3.7215735048958263`*^9}, {3.721573638388783*^9, 
+  3.721573657756658*^9}, {3.721573728540988*^9, 3.721573737865568*^9}, {
+  3.721573864682006*^9, 3.721573871059524*^9}, {3.721573909676648*^9, 
+  3.7215739535510683`*^9}},ExpressionUUID->"6e6e83fe-a091-422f-89b0-\
+b762b3bb1c02"],
+
+Cell[BoxData[
+ RowBox[{"{", 
+  RowBox[{
+   TemplateBox[{GraphicsBox[{{}, {{{}, {}, {
+          Hue[0.67, 0.6, 0.6], 
+          Directive[
+           PointSize[0.005555555555555556], 
+           AbsoluteThickness[1.6], 
+           RGBColor[0.293416, 0.0574044, 0.529412]], 
+          LineBox[CompressedData["
+1:eJxdmjmw81YZhjXQuFRB4YJCeBjmDsMwZjdrFFZDIJhAEocliGyYJYkggRgI
+IJYfHFaXt1Tp0qVLlS5dulSHS5UuGcbf8zPnuc2Z577feo4k6xz7Xc+9+sSL
+b8uy7D9vz7L/jbe/4ZHb+JEy/hHjNMZRjO+NMRe/I8b3xDiOcRLjO8WF2OO7
+FZ+4dxptR9z3SX+//k9fxPmA8n9QdX9I+odVF/NGvo/K/2Pyn8XIPH1c9p9Q
+fZ8Uf0r5Px0jfX5G8R9RfWVaTwMT79EYY16bR1P77LPyh5mHz6X1NOLs84ov
+zr4QY6xXA+P/xRhjHRuY+r+k+DDrNld94uzLMcZ10cCTGL+i/DDr81jKzWOp
+ffZV1QdzfX4t5Qbmunxc9T8u/euqX5wtUvtS3MCRv4Pp7xtp/hKehD8c8TrZ
+Z0+k8UqYeuGYnw6mv2+m9ZVwXN8NjD8c9WXfSrmEWU84rpcO5vp6UvmfTPUG
+jv46mPqfSvXyqVRv4JivTvbZ06l9+XSqN3A8tzpxtlR+mOsRjvnoYOp/Jo1X
+PpPaN+JOnH07xljvEia/uIN5rn4nRq4/OOpppHcw99d30/glzPxJ76Rn31N+
+mP5h7h/ZZ8+m9iXM9Qtz/8Bcf99P45cw8wfjD+NfpfkKmHrgiFfBzI+4lX8H
+x/r2MP3/IK2ngFkPOOJVsm/g6L+Fo59Oeg+zfs+legGT/7nUvpJ9I72Fo74O
+jnp6cfa88j+f6iVMfumN9FZ6B08iv/JlL6T1Fi+k9iXM+osbONanld7B9A+T
+/8XUvoC5n+Cor4Kjvgamf+md9F569lKM8b5YvJTqpbiCuf7FLRzvwZ38e3H2
+w5QLOPotxZW4gWO+WpjPGzjmt4e5/lZpvQUc74uluJJ9A8f7agvHfHby78XZ
+j1L/Ap5EfjjyVXD4N/JvZd/BXH+Kn/04xtjHFHDUX0qv4MjXwFFPK+7k34uz
+n8QY+6pCXML0L72B6R+O+J3se3H20xhjn1fAka+UXokbOPaNrfRO3Iuzl9N8
+xcupXsJRbyW9kd4+1G9/nex72WevxMj6v5LqpfQKJr+4hWM+Oum9OHs15UJc
+iis44jfiVtyJe3FWE//2l9epXoinsi/Fi4cc9Ypr2TeKv5XeivfiTnwS9+JB
+nP0s5VxciKfiUrwQV+IaZv3EW9m30vfiTvYncS8e5J/9PNVzcQGz/uJSvJB/
+9ZBvYy37RryVfQvH/biXfSc+yb+XPihe9lpqn7+W2hfiqbiEI95C8So4nh81
+zOen9C3M54ni7ZWvk/9J8Xvpg/yz11POX0/tC/FU9qX0hfQKjs+nGqZ/2W+l
+t3DMx175OvFJ/r14gDkf/EXqn8O8j8CRfyou4Yi/gOkfjny1/BvxVvat9D08
+uY2d6j3Jv1d9g+yzX6acw+wHpU9h3o9g+pdeSa/FjfJt5d8q/156B8f78Enx
+ejjmbxBnb6TxcnhyG4s3Uvup7Es48i3g2N9UcNRXy78Rb8Wt4u9VXwfH+/5J
++XvVPyh+tk45h2M/UcCRbyr7EqZ/2Veyr6U30rdwzFcLx/nBXvad6j2Jezjm
+ZxBnv0rryWH2w3Dsn6bSSzjiLcQVHOtRK18DR39bOM5rWsXby76D6V96r3iD
+6sl+HWOsXw6zH4cj/xRmfy77Bcx+FaZ/2TeKv4XjvLVVvr24g+P84QTH9yy9
+4g0w59+/iTHOE3M45quAw38K07/0BRznj5X0GuZ8G456t+IWjvnaK34nPqn+
+Xv6D6s/ejDHWK4fp/83Ufgpz3itewPG9VgVHv7XyNfLfwpznwbE+e9l3MOsP
+x/dPvfIPyp/9No2Xw7FeBcz9Ly7hyL+AY/4qmOtf3CjeVv6t6tnLv4N5/ot7
+xR/gSYy/S/Uc5vkHR74pzHm9/Bcwzz/pteI10rfK30rfizvZn2Ce/6pngPn+
+4/dpPznMeSzM+ksvYdYfjvyV9FrxGpjnn+K34j3M+a74JPse5vMf5vpv0npG
+cNSTw/H+NYZ5P4Qj3p38p+IZzPNT8efw5DYu4OhnqXor8UpcK/9a+RvpGzju
+v63y36v/Vv471b+X/UH2nfo/aj5Pyn+W3ivfRf0P6vcK8/73hxjjfXwER7wc
+Zv1lX8AR707+U+kz+Zdw7L/mMPtpOK7fpeqpFG+lfLXqWStfo3gbmPtR8e5V
+T6v8O5j3ddkflK8TH8Un+Z+Vr5f9RfaD+CrO/hhjzPcIjvi59DHM+YDs76RP
+xTNxCUc9c+VbyH4p+0r6SlyL1/JvpG/g6Gereu6lt/LfSd9LPyheJz7CnGfB
+cf5zFvfii/IN4qviZ39KeQRzHiYeiwv530mfimfiUv7zh/rtbyH7pewr8Upc
+i9fiRvE3yr8V38u/Fe/Ee/kfxJ3sj+KT7M/Se+kX8SC+irM/pzwS5+KxuBDf
+iadw1DuTXorn4oV4Ka4UfyW9lr4WN+KN/Lfie9m34p14/9D/Nh5g7n/xUfYn
+OO7fs/Re+kX5B9lflS97kNqPHqT2+YPUfiwuxHfiqeLNYJ7/sp+LF+Kl/Cvp
+K+Wrpa/Fjew34i0cz/N7cat6djDnlYp3kH2neEfpJ/mf4clt7GV/EQ8wn//q
+P/tLqo9gPv/FY5jPf5j1hzkvhqPemfRS8ecw54mqb6n8lXil+DXM+7+4geP9
+biP/rfhe9q30nfrda34Osu/ER/V7kn4W9+ILHPvNAY79wxVm//fXGGM+RnDs
+F3I41mMM83sZmP2feCqeKV4pnsOT27iQ/1JciVcw+2049kNrxW/U/0bxttLv
+VW8Lx/zu4Dhf2Cv/QfE7xTsq3kn+Z5jzPa3XRfUOindVvmyTxh/B7P+lj6UX
+cMS/g6O+Kcz6w/y+EI75msOT27hQ/qXiVdJXqqcWr1VfA8f8bWC+j1L8e9Xf
+Kv5O/ezFB+XrFO8Ix3nnSfpZ8XrpF/U3wHG+dVU/2Vup/+it1D6Ho78xzPcD
+4jv5T6XPFK+UPodjfhaKt5R/JV6pnxqO62UNs/6Kv4Ent3EL8/xXfa14p3h7
+1XNQvZ3qOyreSfNzVv298l0UfxBfxdnfYuT5D/P8hyP+GOZ8HI7vK+6kTxV/
+BnP/w9HPXPpC/kvVV8Fx3r+C4/6tYe5/caP4G+lb6ffK38KxPjv571XPAZ7c
+xk7+R5jvczQ/Z+XvVd9F+QbFu2q+sr+n8UbiHA7/MRzXQyH7O+lT8QyOekvx
+XLyA43pYwny/In0FR3+17NeqpxFvYJ7/MM9/2bfSdzDrD8f9fVA9nfIdZX9S
+/LPmpxdftF4DPLmNV8XL/pH2M4L5PhCO970xzO9jpN/B0c9U+kx6qXhz5V/A
+Uf8S5v6Ho/+V8tVw7C/Witco30a8Vbx71duqn53s97I/KH6neo7q56R4Z8Xr
+xRf1Oyj+VXr2z5RHcOw/cpjzf+mF9DuY81/Zz8QlHP3NYfb/ireUf6X8K/nX
+8l/Lv5H/RvVsNT/38m+l7xRvr/wH1ddJP8Kc/0g/S++lXxR/kH6FOf/9V6qP
+xLl4DLP+4juY/T8c9cwUr5Q+Fy/ES5jfV0pfwfzeTPoa5vxP8Tbirfhe/u1D
+/fa3k/1e9gfpnfSj+CQ+K18v/aL4g+yv4uzfKY/EuXgsLmDO/6VPxbP/838B
+1Gcb9Q==
+           "]]}, {
+          Hue[0.9060679774997897, 0.6, 0.6], 
+          Directive[
+           PointSize[0.005555555555555556], 
+           AbsoluteThickness[1.6], 
+           RGBColor[0.663226, 0.6872815, 0.9117649999999999]], 
+          LineBox[CompressedData["
+1:eJxdmjmQw1YdhzXQuHRB4YJC7DCMh2EYc5sz4goGAogEiCEQlEDAIUAM5HA4
+EhEuc7vcUqVLlS5VulTpUh1bqtySYfz/lnmfmzff/v7nezqf9h3Pvvj4c2/J
+suw/b82y/43X3/jIdXxfEX8oUp7EmMc4jXEe49tinGm8ifHtMb5TcW40zmRH
+nndJn4vfrTjvkf7eGOlroTz0if/7VecHYqTPD4o/pHwflv9HYmQeltI/Kv+P
+xUj/Hxd/QvafVPxPKf4jsi9ivLmONcx8fFo6TLzPpPY1TPzPxhjrVMOsw+di
+jHmtYdbh8zHGutcw6/ZojLHO9aOpffYF1S/OVmm+Gua4+aL8YY6LL8UY/dYw
+/l+Okf5h1uexGGM+68dS++wrMTK/4uyrqg/G/2vKDzM/ZRqvgKO+ukztO5j1
++3oav4BZDzjidzDHz+MpF+IajvgdTP1PpPUU4vqJ1L6DWZ9vqH6Y+Ybxhzk+
+vxnjTfjD5IcjXwezft+KMa5bBUz/MP2LsydjjOOveDLVa5j8cNSbrdN+Cpj8
+MP4w59+303wFHP3UcOTrpGffSbmAmT9xJ/vsqbSeAuZ68VRq38HM33djjOO9
+gOlf3MGs3/divAl/OO4HNczxI86elj/M8QeTX/bZ99N+CpjrERz1dDDHfxVj
+zE8OUw8c9VQw8wtHfQ0c+Tv5D7LPnknz5c+keiGuYK5P4gbmfIGj3wFm/Z5V
+fnEBR78VTH444jWy7xRvgJn/H6Txcpj+pVfSazjiN7LvpA8wx98PY4zzJ4fJ
+L65g1l/cyL6DyQ9z/3su5RwmPxz+lfRa/o24Ew/yz36Uci4u4Dh/KpjzCyY/
+zPor3iD/7Mcp53A8ZxfSK/gm8osbcQdHPQPM8b+JkfMf5noCkx9m/mH6h+P5
+tIOjnwHmefn5NH7+fKoX4kr2NRz5GjjydXA87w/Ss58oP8z9AI74FRzvSbX0
+RvE62Q8w+V9I9fyFVC+kV9JrcQMz/9IHmPefn6acw5GvkF6JazjWp4GZf8Ub
+pGc/S/UcjvjFA19/lexrcQOTX/qg+NnPlR9m/sWV7Gs44jWy7x70628QZy8q
+P0z/0itx/WB//TXSO/Eg+2yb8lScw+G/kF5IL6VX0rcP+nWspR/k34hbcSfu
+xYN4FGe/SHkqzsULcSEuxZV4K65h+hc34lb+nfRePIhHcfbLlKfiXLwQF3Cs
+Zym9etCvv624lv9B/o30Fub8kt6LB/Eozn6V8hSO+DlM/+Liwf/6K8WVeKt8
+teIdpDfSW+mduJf9AMf9aFR/2UspT19K7XOY/mVfSC9h7hdw3I+28q+lH8SN
+4rfiTvl68aB8I8zzx8spT19O7XPpC5j3bTjqLWVfyX4rvZZ+UP5G3Mq+k96r
+nkH6CHP8v5LaT19J9RyO570FTP/iEuZ+CUe/W+WrxQdxI/9W+TrpvfwH1T/C
+PP++GuPNdZy+mtrncORbiAs4nq9LmPdl8Vb5avFB8Rs4nkdbcSf7HqZ/OJ7n
+R/WX7dL8012q5zDHv/QCjnpKmPMf5vhXvFp8ULxG/i3MfqK4h3nfEY/i7LXU
+f/paqufiBXxzHQv5l+IKjvnfwuyPKt5B+RrFa2H2w+Tfw7xvSh8VL/t1Wt8U
+jvpymPMf5v0IjvUrpVfStzDvb+KDuFG8VvV0su+lD3Dsb4zqL/tNjDHfUzj2
+93M45mcBs98MR7wSjvfpSryVfy39oHoa2bcw57/8e/kPqn+EWf/fxhjzM4Uj
+Xy59AbNfC3P8S6+kb2GOfzj2nw9wfFdr4OinhdnfU7294g3KPyp/9ruUpzD7
+ITDnv7iAuf7B7JeJtzD7u/DNdTxIb+Tfqr4Opn/5D4o/wux/v57Gm76e6rl4
+AXP+w1FfCUc9lfy3sq9hrv9w1NuIW5j9NdXTy36Q/SjO3oiR/mGO/zdS+wXM
+9xLZl3AcTxUc9W1hvs+ID+JG+Vs4+usUv4e5/olHmO/HdcoTOK6nUzjyzcQ5
+HPHn0hfipewLOPpbwZxP4rX8K8XfwFxvFH+n/mrF2yvfAY7j81Z6Iz7KvoXj
+efik+e5U71n19NIv6meA43i5k/+ofPfSs9+n9U9g3ofg8J/BPB/C0d8c5nlZ
+8ZbSC+kr5SvFa+WvxBv45jpu1d9O9rXq2SvfQf63sm9kf9R8tMp3UrxO+lnc
+a34u8h+U/072o/R76dmbKU/eTO2ncDzPz2Dej8VzxVvA0c9S9gUc7/Mr5Sul
+r8WV6t3Ifyveqb4aZv0V/6D4t+JGfFS+VnySfSc+y75/4OvvovoG2d+JR/G9
+/LM/pDyB4zeVPhPnsp+LF+KluHjg67hS/FL2a+mV/Dfirex3ileL9/I/yP9W
+3Mj/KG5lf5Leic/iXnwRD4p/J30U34uzP6Y8EU/FM3EunosX4qW4EK/EpXgt
+rsQbmO8N4p3sa/FefJD/rbiR/VHcik/y76SfpffSLw98HQfpdzD7fbK/V/zs
+T6k+EU8f+PqbwZz/4jkc+RfipeIX0lfiUryWf6X6NqpnK30n/1q8Fx/EtzDf
+O5XvKG7huL6fxJ36Oyt+L/uL6hmk34lH9X+vfNmfU56IpzD3f+k5HPXOpS/g
+qGcJ8/wPx/13JftS+lpciTeqdyveqb5a+fbwzXU8wDz/iRvlP2o+Wjie30/S
+O/FZ8XvN10X6oPx36m9Uf/eyz/6S1jeBI/4UjvpmMN+HZD+Hb67jQrxUvkL+
+K8Uv4eh/rXgVHO9DG5jvTeKduFZ/e9V3UPxb5W9U/1Hcqv6T8nWKfxb3quci
+/0H57uQ/yv9eerZP65vsU30Kx/vlDL65jjkc+ydzOOpZwLEfsoT5/x7lX4lL
+8Vr1VHD0t1F9W/nvpNeqf6/4B9nfan4aOPZ/jsrXyv8k/072Z81XD8d+00X9
+Dop3p/pH6ffqN/traj+Bo94pHPXNYL6PwFHvHI75WCjeEmb/UP4r1VOK13Ds
+R1eKvxFvZb+TXqufvfId4JjvW5j3f9V/lH8Lx3yfxJ3m66z57mV/Uf2D+E75
+R/V3r3qzv6X6BI78Uzjiz2Sfw1H/HI56F3Acv0vZF4q/gll/xVvDrL/ibZRv
+q3g7xavlv5f9Aeb+r/lpFO8ovZV+gvl/es3nWfPRy/+i+gb1eyd9hLn+K372
+97SeCcz6w9H/DOb+L/+5/Bdw9LeE+f9SOPpbyb5U/DXM91XpGzj628p+p/i1
+6t2rvoPqu5V/I/uj8rWq76T57BT/LL1XfRf1Nyj/ndZnlP+9OPtHaj+BI/5U
++kyci+cw93+Y/T9xAbP/r/wlHPO5ln8l3sB8b5X/Dub5T/571X+Q/y3M9xnV
+e4R5/le8k+J10s+qr9f8XqQP4juY53+Y93/Fy/6Z1juB2f+VPpOew+z/wpFv
+IX0p/0L2K+UrxWvZV3C8b28Ufyv73QNff7Xq28v+oHi30hvpR3ErPok71X9W
+Pb30i/RB9dyJR/G95jP7V6pPxFPx7IGvvxyOfuYw/y8o/6W4kP1Keil9La5k
+v1E9WzjmayeuFW8v/SD9Vvka6UdxK/uT5q+T/Vncy/4ifRDfyX5U/ntx9u/U
+fwLHbyqeyT6XPhcvxMv/838BklUXBw==
+           "]]}, {
+          Hue[0.1421359549995791, 0.6, 0.6], 
+          Directive[
+           PointSize[0.005555555555555556], 
+           AbsoluteThickness[1.6], 
+           RGBColor[0.941176, 0.906538, 0.834043]], 
+          LineBox[CompressedData["
+1:eJxd2zuw80YZxvEdaFyqoHBBIc4wjIdhGHE314i7uSvhEhMu2YQETCCJuAQM
+gbAJNxNIUOlyS5cqXW7pUqXL7XCp0iXDaB8x+1ej+eV533dX0rGPzzlf3vH0
+i489+xZjzH/easz/ztMxPjKdizr9h3R+Wzov0vntdV6nPtUtcVad+jS3lNPx
+gHXeCb8L+1lhnXdj/nvQ/17kFfw+7Pf96P8A/EH4Q/CH4Y+ks+7XWuun46PY
+z8dQ/3H4E9jvJ+FPwY/Adb4/B5tP5/VO1v3/TL5fB5vPol/W8/pcPs/JWv/z
+6Jc1/wvYv6z5X8ztZO1/k87p69Jt8nrzJfTL2t+Xkcva31ewP9h8Fbms5/u1
+fJ6DzdfTWfcHNt9ALmv9Jt9/Let5wEHW/EfzvH40z52c9htQbx7L62tZ9+Ox
+vD7Ieh/5JtaHnZzeZwJy8618vRp2ctpfkHX/v53Oun+y+uEg6/59R/PSVNjB
+QdbXx+PYv6zrfzyvD7K+vrfol/V6kHX9sPluPr+WtT4cZL3vP5HPq5/I652c
+9htg8718v7Ws+w8HWfv/fp7XcroehzzA5gfol7V/5AG5+SH6Zb1+ZL1+UG+e
+VJ6qnszrnaznL6vf5i7l1F/DFvUOuUce4Ih681Q6p+stn8rra9jKur+wR32A
+I9YzT2N9uJZ1/bLe72WtjzxgXsQ88yN5OkpZ1y+n+RZ2cnq+fp6X1se8iNw8
+k/eXz+R5Lev+o97BXtbrHf0RNs+ms+6/rPeTZ/N6K+v6YY95AY6yrv/HuUtZ
+68taH/UOuUce4Aibn8jTUcp6/rCV9f4w96f14QBHWe8/u3TW84drWV//yB3s
+4SDr+WOe+SnWh2tZ14/cyel+eFmvP1nXD5vn8v5SVtVzeb2VtT7s0R+QR9j8
+LHcpa1XYot4h98gD8jg7nX+eu5yd/ityCzvUe1nry3r+yM3zeX/5fJ7XyC3s
+YA8HzIvIzQt5XsL1C3m9nT2dHXIPBzjC5sXcpaz153w6W9Q72MMBjrBpcxdw
+CVey9oe8gS3cot8h72AP93CABzjCI2x+kbuAS7iCa7iBLdzCDu5gD/dwgAc4
+wiNsfpm7gEu4kvX8kTfILfIWuUPeIffIezigfoDjXD+dR/SbX+X1BVzClayp
+cIN6C7eod8g75H72dO5RH+AB9RH5KOvz16/z+mL2dJSyrh+u4Qa2mNfK+vkB
+9R3qPdxjvwH9AxzhEf3mpTwv5HSUL+X1FeprOV1PA1u4Rb/Deh1yj/V75AEe
+MC+if4TNb/L+QtbPg3Al6+cD5A1yi/ktcgd3sj7PIe/hgPkD+iPqR9Sb3+b7
+L2R9HpTT7xcq5LWsr39Z14/5LeY55B3sMa+Hw+zpGJBH5CP2a/b59RSynj9c
+yXr+6G/k9Pnbor6V9fWP+R1yj/m9/DCdA/oH9EfkI/ZjfpfnhaznL6eflyq4
+ltP1NnJ6vhbzW9ihv0Pu5Yfp3CMP2M8g6/njekasZ36f9xeyfh6Q9fxlvf+h
+vpHTehb1LeY5Od2vDrnH/npZv8+VH6bzgPqI/Yyyrv/lfF7xcl5fvpzXV7Ke
+v6zrl/X+j/oW8xzcod9jfo88yHr/w/4j1h8xz/whzwu4lNO8Cnktp/vXoN7K
+6fpa9DtZzx+5R3+PPCAfZP28ifkj6s0f8/pC1vOX9fpHXsMN6q2c1m9R77B+
+B3tZzx95QD7AcfZ0jMjNK+ms7/+v5PXlK3l9JevvHXK6vgb1Fm5hJ6f70cl6
+/livl3X9WH/AvAiPWN/8SU5lsj7/y3r/k/X8kTfIraznj9zJ6Xq7eT/T2cM9
+HLDfAdcTUT/CxuX7X8jpfhfIl7K+P8hp/RXyCl5jXi2n+7GBG/Rv0W+x3x3y
+Ft5jvsP8A66nQ/8R9qg/YV6P+jMc4As8YN4Vjqi/YT8jfJ/70/Fqni9ezfNC
+Tl+fS1mfD+V0P1dz/3SuUL/GejXqN3CD/i36Lfa7g1vU7zHfwQe4Q/8R8z3y
+E/Ie+Rn3KyC/YP0B9Vfcj4j8hnkj9nPHfPNaPm8h6/vBa3n9EnkJr+Bq7p+O
+NfIa3sAN1t/CFvU7XE8rp/uzR73D/g6o77DeEf0ePqG+x37OyAP6L/AAX+GI
+/d/gEb7D5s+5F3ABL+ESXsEVvJb1/JFvkDfwFrbo38EtvIcdfIA7rHdE7uET
+3MNnOMAXeICvcIRv2O8I31Fv/pJ7ARfwEi7hFVzBa7iGN3ADb2EL7+AW3st6
+/SM/IO+QH2EPn+AePsMBvsADfIUjfINH+A6bvybr+z9cwEs5HSW8giv0r5HX
+yDfIm9nTeYt6C+/Q3yLfww4+wB3mHWGP/Z3gXtb7P/oDfIEH7OeKPGK9GzzC
+d8wzf8u9gAt4CZfwStbnP3iN+nrOp2OD+gb5FrbwDm7hPdZ3WO+AvIOPqPfw
+SU7Pu4fPqA/wBesN8BXXE5HfMG/E+ndZ//7j7+mcPu8sZP09CF7CpaznD1fw
+Gq6x/kZO+2tkff7H+hbzdnCL+j3mOax/QH0HH1Hvsd8T5vfwGf0BvmD/A+Zf
+sZ+I+Tc5/Tw8Ir/D5pDPX8j6+R/5Uk6/zyjhlazfF8p6/WNejfoN1m/gLeot
+vMN6LdbbI3ey3v/hbq6fjiP6PXyCe+z/jP0E5Bf0D9jPFXnE9d8wf0T9HTb/
+yPsXsn4fLOv3P3AJr2T9vlxOvx9ey/r3ulh/g/oG87bYn8X6O1nPX9b3f9Q7
+1B+Qd8iPyP2cT8cJ++3hs5z+v5YgP0znC+oHrH+FI3xD/4j7e0e9eT3PF6/n
+eYF8Kev5o34FV3Lazxr9tZye5wb9DfIt+i32t8N6rfwwnfey/v6KeQdZr3/k
+R+R+3u90nLB+j/4z9hsw74LrHXA/rth/RP0N80f032Hzz3z9hay/h8h6/rL+
+PoT+FeorzFvLD9O5ltP1bDC/gbeYbzF/h7xFvocdfMB6HeYdYQ+f4F5O9/ss
+69+nYv0LPMBXzIuzp+OG+hHr3ZGbf+VeyPr3ALK+/8vpKGdP5xX6K8xfwzW8
+QX+DfAtb1O+wnxbeo97h+g7IO6x3xDyP/IR5PfKzrH+/g3kXrD/AV9RH+AaP
+8B3rmzeUp22+kdcXb+T1S7hE/wr9FbxGfw1v4AbeYp5FvoNb7G+P3MEHuIOP
+sMf8E9yj/gwH+ILrGzDvCkf03+ARvsPmzXy9BVy8mdcvZX3/h1eyXv/I15hf
+wxu4wfpb5Bb5bs6no4X3qHfwAe7gI+Z55CfkPXxGfUB+gQf4Ckf4Bo/wHTb/
+zr2Q9fsfeIn6El7BFbz+v/8LvN4eZQ==
+           
+           "]]}}}, {}, {}, {{}, {}}, {{}, {}}}, {
+      DisplayFunction -> Identity, PlotRangePadding -> {{
+          Scaled[0.02], 
+          Scaled[0.02]}, {0, 
+          Scaled[0.05]}}, AxesOrigin -> {0., 0}, 
+       PlotRange -> {{0., 999.}, {0, 24.}}, PlotRangeClipping -> True, 
+       ImagePadding -> All, DisplayFunction -> Identity, AspectRatio -> 
+       NCache[GoldenRatio^(-1), 0.6180339887498948], Axes -> {True, True}, 
+       AxesLabel -> {None, None}, AxesOrigin -> {0., 0}, DisplayFunction :> 
+       Identity, Frame -> {{True, True}, {True, True}}, 
+       FrameLabel -> {{None, None}, {None, None}}, FrameStyle -> Directive[
+         GrayLevel[0.5], 
+         Thickness[Large]], 
+       FrameTicks -> {{Automatic, Automatic}, {Automatic, Automatic}}, 
+       GridLines -> {Automatic, Automatic}, GridLinesStyle -> Directive[
+         GrayLevel[0.5, 0.4]], ImageSize -> 750, 
+       Method -> {"CoordinatesToolOptions" -> {"DisplayFunction" -> ({
+             (Identity[#]& )[
+              Part[#, 1]], 
+             (Identity[#]& )[
+              Part[#, 2]]}& ), "CopiedValueFunction" -> ({
+             (Identity[#]& )[
+              Part[#, 1]], 
+             (Identity[#]& )[
+              Part[#, 2]]}& )}}, PlotRange -> {{0., 999.}, {0, 24.}}, 
+       PlotRangeClipping -> True, PlotRangePadding -> {{
+          Scaled[0.02], 
+          Scaled[0.02]}, {0, 
+          Scaled[0.05]}}, Ticks -> {Automatic, Automatic}}],FormBox[
+      FormBox[
+       TemplateBox[{"\"M\"", "\"R\"", "\"S\""}, "LineLegend", 
+        DisplayFunction -> (FormBox[
+          StyleBox[
+           StyleBox[
+            PaneBox[
+             TagBox[
+              GridBox[{{
+                 TagBox[
+                  GridBox[{{
+                    GraphicsBox[{{
+                    Directive[
+                    EdgeForm[
+                    Directive[
+                    Opacity[0.3], 
+                    GrayLevel[0]]], 
+                    PointSize[0.1], 
+                    AbsoluteThickness[1.6], 
+                    RGBColor[0.293416, 0.0574044, 0.529412]], {
+                    LineBox[{{0, 10}, {20, 10}}]}}, {
+                    Directive[
+                    EdgeForm[
+                    Directive[
+                    Opacity[0.3], 
+                    GrayLevel[0]]], 
+                    PointSize[0.1], 
+                    AbsoluteThickness[1.6], 
+                    RGBColor[0.293416, 0.0574044, 0.529412]], {}}}, 
+                    AspectRatio -> Full, ImageSize -> {20, 10}, 
+                    PlotRangePadding -> None, ImagePadding -> Automatic, 
+                    BaselinePosition -> (Scaled[0.1] -> Baseline)], #}, {
+                    GraphicsBox[{{
+                    Directive[
+                    EdgeForm[
+                    Directive[
+                    Opacity[0.3], 
+                    GrayLevel[0]]], 
+                    PointSize[0.1], 
+                    AbsoluteThickness[1.6], 
+                    RGBColor[0.663226, 0.6872815, 0.9117649999999999]], {
+                    LineBox[{{0, 10}, {20, 10}}]}}, {
+                    Directive[
+                    EdgeForm[
+                    Directive[
+                    Opacity[0.3], 
+                    GrayLevel[0]]], 
+                    PointSize[0.1], 
+                    AbsoluteThickness[1.6], 
+                    RGBColor[0.663226, 0.6872815, 0.9117649999999999]], {}}}, 
+                    AspectRatio -> Full, ImageSize -> {20, 10}, 
+                    PlotRangePadding -> None, ImagePadding -> Automatic, 
+                    BaselinePosition -> (Scaled[0.1] -> Baseline)], #2}, {
+                    GraphicsBox[{{
+                    Directive[
+                    EdgeForm[
+                    Directive[
+                    Opacity[0.3], 
+                    GrayLevel[0]]], 
+                    PointSize[0.1], 
+                    AbsoluteThickness[1.6], 
+                    RGBColor[0.941176, 0.906538, 0.834043]], {
+                    LineBox[{{0, 10}, {20, 10}}]}}, {
+                    Directive[
+                    EdgeForm[
+                    Directive[
+                    Opacity[0.3], 
+                    GrayLevel[0]]], 
+                    PointSize[0.1], 
+                    AbsoluteThickness[1.6], 
+                    RGBColor[0.941176, 0.906538, 0.834043]], {}}}, 
+                    AspectRatio -> Full, ImageSize -> {20, 10}, 
+                    PlotRangePadding -> None, ImagePadding -> Automatic, 
+                    BaselinePosition -> (Scaled[0.1] -> Baseline)], #3}}, 
+                   GridBoxAlignment -> {
+                    "Columns" -> {Center, Left}, "Rows" -> {{Baseline}}}, 
+                   AutoDelete -> False, 
+                   GridBoxDividers -> {
+                    "Columns" -> {{False}}, "Rows" -> {{False}}}, 
+                   GridBoxItemSize -> {
+                    "Columns" -> {{All}}, "Rows" -> {{All}}}, 
+                   GridBoxSpacings -> {
+                    "Columns" -> {{0.5}}, "Rows" -> {{0.8}}}], "Grid"]}}, 
+               GridBoxAlignment -> {"Columns" -> {{Left}}, "Rows" -> {{Top}}},
+                AutoDelete -> False, 
+               GridBoxItemSize -> {
+                "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+               GridBoxSpacings -> {"Columns" -> {{1}}, "Rows" -> {{0}}}], 
+              "Grid"], Alignment -> Left, AppearanceElements -> None, 
+             ImageMargins -> {{5, 5}, {5, 5}}, ImageSizeAction -> 
+             "ResizeToFit"], LineIndent -> 0, StripOnInput -> False], {
+           FontFamily -> "Arial"}, Background -> Automatic, StripOnInput -> 
+           False], TraditionalForm]& ), 
+        InterpretationFunction :> (RowBox[{"LineLegend", "[", 
+           RowBox[{
+             RowBox[{"{", 
+               RowBox[{
+                 RowBox[{"Directive", "[", 
+                   RowBox[{
+                    RowBox[{"PointSize", "[", "0.005555555555555556`", "]"}], 
+                    ",", 
+                    RowBox[{"AbsoluteThickness", "[", "1.6`", "]"}], ",", 
+                    InterpretationBox[
+                    ButtonBox[
+                    TooltipBox[
+                    GraphicsBox[{{
+                    GrayLevel[0], 
+                    RectangleBox[{0, 0}]}, {
+                    GrayLevel[0], 
+                    RectangleBox[{1, -1}]}, {
+                    RGBColor[0.293416, 0.0574044, 0.529412], 
+                    RectangleBox[{0, -1}, {2, 1}]}}, AspectRatio -> 1, Frame -> 
+                    True, FrameStyle -> 
+                    RGBColor[
+                    0.19561066666666668`, 0.0382696, 0.35294133333333333`], 
+                    FrameTicks -> None, PlotRangePadding -> None, ImageSize -> 
+                    Dynamic[{
+                    Automatic, 1.35 CurrentValue["FontCapHeight"]/
+                    AbsoluteCurrentValue[Magnification]}]], 
+                    "RGBColor[0.293416, 0.0574044, 0.529412]"], Appearance -> 
+                    None, BaseStyle -> {}, BaselinePosition -> Baseline, 
+                    DefaultBaseStyle -> {}, ButtonFunction :> 
+                    With[{Typeset`box$ = EvaluationBox[]}, 
+                    If[
+                    Not[
+                    AbsoluteCurrentValue["Deployed"]], 
+                    SelectionMove[Typeset`box$, All, Expression]; 
+                    FrontEnd`Private`$ColorSelectorInitialAlpha = 1; 
+                    FrontEnd`Private`$ColorSelectorInitialColor = 
+                    RGBColor[0.293416, 0.0574044, 0.529412]; 
+                    FrontEnd`Private`$ColorSelectorUseMakeBoxes = True; 
+                    MathLink`CallFrontEnd[
+                    FrontEnd`AttachCell[Typeset`box$, 
+                    FrontEndResource["RGBColorValueSelector"], {
+                    0, {Left, Bottom}}, {Left, Top}, 
+                    "ClosingActions" -> {
+                    "SelectionDeparture", "ParentChanged", 
+                    "EvaluatorQuit"}]]]], BaseStyle -> Inherited, Evaluator -> 
+                    Automatic, Method -> "Preemptive"], 
+                    RGBColor[0.293416, 0.0574044, 0.529412], Editable -> 
+                    False, Selectable -> False]}], "]"}], ",", 
+                 RowBox[{"Directive", "[", 
+                   RowBox[{
+                    RowBox[{"PointSize", "[", "0.005555555555555556`", "]"}], 
+                    ",", 
+                    RowBox[{"AbsoluteThickness", "[", "1.6`", "]"}], ",", 
+                    InterpretationBox[
+                    ButtonBox[
+                    TooltipBox[
+                    GraphicsBox[{{
+                    GrayLevel[0], 
+                    RectangleBox[{0, 0}]}, {
+                    GrayLevel[0], 
+                    RectangleBox[{1, -1}]}, {
+                    RGBColor[0.663226, 0.6872815, 0.9117649999999999], 
+                    RectangleBox[{0, -1}, {2, 1}]}}, AspectRatio -> 1, Frame -> 
+                    True, FrameStyle -> 
+                    RGBColor[
+                    0.4421506666666667, 0.45818766666666666`, 
+                    0.6078433333333333], FrameTicks -> None, PlotRangePadding -> 
+                    None, ImageSize -> 
+                    Dynamic[{
+                    Automatic, 1.35 CurrentValue["FontCapHeight"]/
+                    AbsoluteCurrentValue[Magnification]}]], 
+                    "RGBColor[0.663226, 0.6872815, 0.9117649999999999]"], 
+                    Appearance -> None, BaseStyle -> {}, BaselinePosition -> 
+                    Baseline, DefaultBaseStyle -> {}, ButtonFunction :> 
+                    With[{Typeset`box$ = EvaluationBox[]}, 
+                    If[
+                    Not[
+                    AbsoluteCurrentValue["Deployed"]], 
+                    SelectionMove[Typeset`box$, All, Expression]; 
+                    FrontEnd`Private`$ColorSelectorInitialAlpha = 1; 
+                    FrontEnd`Private`$ColorSelectorInitialColor = 
+                    RGBColor[0.663226, 0.6872815, 0.9117649999999999]; 
+                    FrontEnd`Private`$ColorSelectorUseMakeBoxes = True; 
+                    MathLink`CallFrontEnd[
+                    FrontEnd`AttachCell[Typeset`box$, 
+                    FrontEndResource["RGBColorValueSelector"], {
+                    0, {Left, Bottom}}, {Left, Top}, 
+                    "ClosingActions" -> {
+                    "SelectionDeparture", "ParentChanged", 
+                    "EvaluatorQuit"}]]]], BaseStyle -> Inherited, Evaluator -> 
+                    Automatic, Method -> "Preemptive"], 
+                    RGBColor[0.663226, 0.6872815, 0.9117649999999999], 
+                    Editable -> False, Selectable -> False]}], "]"}], ",", 
+                 RowBox[{"Directive", "[", 
+                   RowBox[{
+                    RowBox[{"PointSize", "[", "0.005555555555555556`", "]"}], 
+                    ",", 
+                    RowBox[{"AbsoluteThickness", "[", "1.6`", "]"}], ",", 
+                    InterpretationBox[
+                    ButtonBox[
+                    TooltipBox[
+                    GraphicsBox[{{
+                    GrayLevel[0], 
+                    RectangleBox[{0, 0}]}, {
+                    GrayLevel[0], 
+                    RectangleBox[{1, -1}]}, {
+                    RGBColor[0.941176, 0.906538, 0.834043], 
+                    RectangleBox[{0, -1}, {2, 1}]}}, AspectRatio -> 1, Frame -> 
+                    True, FrameStyle -> 
+                    RGBColor[
+                    0.6274506666666667, 0.6043586666666667, 
+                    0.5560286666666667], FrameTicks -> None, PlotRangePadding -> 
+                    None, ImageSize -> 
+                    Dynamic[{
+                    Automatic, 1.35 CurrentValue["FontCapHeight"]/
+                    AbsoluteCurrentValue[Magnification]}]], 
+                    "RGBColor[0.941176, 0.906538, 0.834043]"], Appearance -> 
+                    None, BaseStyle -> {}, BaselinePosition -> Baseline, 
+                    DefaultBaseStyle -> {}, ButtonFunction :> 
+                    With[{Typeset`box$ = EvaluationBox[]}, 
+                    If[
+                    Not[
+                    AbsoluteCurrentValue["Deployed"]], 
+                    SelectionMove[Typeset`box$, All, Expression]; 
+                    FrontEnd`Private`$ColorSelectorInitialAlpha = 1; 
+                    FrontEnd`Private`$ColorSelectorInitialColor = 
+                    RGBColor[0.941176, 0.906538, 0.834043]; 
+                    FrontEnd`Private`$ColorSelectorUseMakeBoxes = True; 
+                    MathLink`CallFrontEnd[
+                    FrontEnd`AttachCell[Typeset`box$, 
+                    FrontEndResource["RGBColorValueSelector"], {
+                    0, {Left, Bottom}}, {Left, Top}, 
+                    "ClosingActions" -> {
+                    "SelectionDeparture", "ParentChanged", 
+                    "EvaluatorQuit"}]]]], BaseStyle -> Inherited, Evaluator -> 
+                    Automatic, Method -> "Preemptive"], 
+                    RGBColor[0.941176, 0.906538, 0.834043], Editable -> False,
+                     Selectable -> False]}], "]"}]}], "}"}], ",", 
+             RowBox[{"{", 
+               RowBox[{#, ",", #2, ",", #3}], "}"}], ",", 
+             RowBox[{"LegendMarkers", "\[Rule]", 
+               RowBox[{"{", 
+                 RowBox[{
+                   RowBox[{"{", 
+                    RowBox[{"False", ",", "Automatic"}], "}"}], ",", 
+                   RowBox[{"{", 
+                    RowBox[{"False", ",", "Automatic"}], "}"}], ",", 
+                   RowBox[{"{", 
+                    RowBox[{"False", ",", "Automatic"}], "}"}]}], "}"}]}], 
+             ",", 
+             RowBox[{"Joined", "\[Rule]", 
+               RowBox[{"{", 
+                 RowBox[{"True", ",", "True", ",", "True"}], "}"}]}], ",", 
+             RowBox[{"LabelStyle", "\[Rule]", 
+               RowBox[{"{", "}"}]}], ",", 
+             RowBox[{"LegendLayout", "\[Rule]", "\"Column\""}]}], "]"}]& ), 
+        Editable -> True], TraditionalForm], TraditionalForm]},
+    "Legended",
+    DisplayFunction->(GridBox[{{
+        TagBox[
+         ItemBox[
+          PaneBox[
+           TagBox[#, "SkipImageSizeLevel"], Alignment -> {Center, Baseline}, 
+           BaselinePosition -> Baseline], DefaultBaseStyle -> "Labeled"], 
+         "SkipImageSizeLevel"], 
+        ItemBox[#2, DefaultBaseStyle -> "LabeledLabel"]}}, 
+      GridBoxAlignment -> {"Columns" -> {{Center}}, "Rows" -> {{Center}}}, 
+      AutoDelete -> False, GridBoxItemSize -> Automatic, 
+      BaselinePosition -> {1, 1}]& ),
+    Editable->True,
+    InterpretationFunction->(RowBox[{"Legended", "[", 
+       RowBox[{#, ",", 
+         RowBox[{"Placed", "[", 
+           RowBox[{#2, ",", "After"}], "]"}]}], "]"}]& )], ",", 
+   TemplateBox[{GraphicsBox[{{}, {{{}, {}, {
+          Hue[0.67, 0.6, 0.6], 
+          Directive[
+           PointSize[0.002777777777777778], 
+           AbsoluteThickness[1.6], 
+           RGBColor[0.293416, 0.0574044, 0.529412]], 
+          LineBox[CompressedData["
+1:eJxd2zmQM0cVwPEuSBQqINiAYFBRlIpyUeIWpwdsQNzCgBGXGT74QFz2YMDI
+NobhFphD4YYTKlS44YQbTrjhZGw4oUKK0vsv1f9Nun5+r1+/7tE5+vyWRy88
+8/gNKaX/vDGl/42Xv/HJy/hEGf8hxvfGOCnz+DTGWYxvivFtMV7F+I4Y3xzj
+W2Ms9N9nGslzXTzXOm9X/AnF6YN9LLSPd2r+u+R3q7/3aB+cE+u9L0b2936t
+t1T+B1T/g6r/IfXzYdX7iPI/GiPn9GSMnEuZr9fI6WN5vQazn4/HGNelwfT3
+lOo/leenp/N6zdN5fvqE1sfM/2SMsb9GTp9SfUz9lepjzufTMcbjsMHs/zMx
+xn4bTP3Pqj/M9fmc1sec3+fVP+Z6fyFfr8H0/8UY43nRyGmd1y8x9XCcd4fp
+/0u5S0y/OPbfYfp7Jq9fyg2Ofjs5fVnzMf3j6KfDnO9X8vwSc144rn+Hed34
+ah4vMevjuF4d5vH7bL5eieN8mmfz/A7z+P5ajPG6VmIer5j9Y85vk69XYh6v
+cienr+f1S0z/mPNTfvpGXq/EXH88i/ly+maMcT1LzHwc59Nh3le+leeXOOo3
+ineY/r8dY7xPlpjnM2b/iqfn8v7K5/J4g2N/neLpO7lLzPXD8f7S4VmMVd5f
+UeXxUvEK0x+O/beKdzjWHxRP381dYB5PcqX8RvEWR/8djv4H5adHWv9Rnl/K
+lfIbHOu1mOc7Zv+Y9b8XYzy+Chz1SrnCrK/5rfI7HOsNmM8b38/7LeQSc/44
+5jdyi3m843i9GRRPj/N+C7l8nOdXmOc3jvNoMa9Xyh+Un34QYzx+C8zrCY7z
+qHB8fmwwjz/M41/1Bjn9MJ9f4DjPEsf5VZjrj6Neizl/HOcxKJ62ebzY5vES
+R/0Ks3/FW8U7HOc3YM7/RzGyfzyL9THrY/aPefxh1sdxfQflpx/n/RWY6y9X
+ciO3cod5/mG+f/wk76+Qywdf/irM+jjqtXKn/EH1009jjO99BebxJ1c4zquR
+W8z6mPNXPP0sd4GjnxLH/OrBl79GblWv0/xBTs9r/efzeClXOPprNL9VvNP8
+QfH0Qt5/8UIeLxWvFG8e4rG+4p3ig+qlOs+f1nm8UHyheCmv5Uqu5UY+yK18
+kju5lwd5lNPPc0/lQl7IpbyWK7mWG/nw4MvY4jj/k/I7uZcHzR8VTy/m601f
+zOOFvMA8PuU1judDpfm18hv5ILfySe7Ufy8Pyh/VT/pFHp/KBY56iwfHf1V8
+rfmVXMuN5h8wryfySe40v8e83is+an76Ze4p5v0Q8/yXS3mtehWO9WvFGxzv
+Lwet3yr/JHfK7xUf5FH9pF/lnmKuP476Cxz1Shz9rxWvVL+WG6130PwWx/U8
+yR2Ozxc9js9HA55dxlH100v5/CmO/RQv5fkLzOcjHJ+v16pXqV6teKP4QW5x
+7OekeKf+esznTXlU/+nXeT9TzP4VX2C+b+Oov9b8Csfn6Vr1Ghz9HFSvxbPL
+eFK8Uz+96g+qP2p+2uXxKeb7sLzAPP4VX+Pot8LRT425P6H5B8z+5ZPcqX4v
+DzjOf8Tc/3o5xnj8Tl/O8wsc13OBuT8hr/HsMlaqV2u9Rj7guH/W4vgd4qT1
+Os3vMd+3lT+qn/RK3u/0lTxeYK4/5n4ljuu5xvE7SqV4rfUa+YDZv3xSvU79
+9Jjv+9rPqPnp1Rjj+k5fzfMLHP0tMPvHcf9ujWP9SvVrzPNf9Q+a38onzP0F
+HPvp5UH9jlov/Sb3FMf1K3DMX2DuD+C4PmvFK8VrzONf6x9wnGereifld8rv
+1e+Aef3T/PRanj99LY8XmNd/zP1qHP2tMddf8Rpz/0z5B9VvMY9/zP1sHL9H
+9Ko3aL0R8/r/23x/Uzy7jAWOegvM+x+O81srXmGe/6rf4OjnoHiLuf7qp8Ox
+v17rD4qPiqff5Z7iWL/Asf5C+SXm84/yK+XXcoPZP+bzD47rc9J6ndbrFR+0
+n1HrpybGeD+fYF4Pmzz/SvkFjv7myl8ovlT9Esf+V4qvcexvg7kfh2O/W82v
+8ewy7tRfo/he9Q7Kv5Zb7e+o/k6K3yjeybfqp5fvlD+o/r3yR/ms806/z/cz
+wXwexFH/CnO/Esf3lznm+5LqLRUvcVyvlbyWN+qnkrfaT635Ozy7jI3y9+r3
+oPi14q18lE86r5sHX/46HM+nW7lX/3fyoPO8V3xUP2c5/SHGuH4TzPdhHPWv
+FC9w9DuXF/IS8/1RXmm9tfrbqF4lbzW/Vr875TeK77XeQfWuFW9V7yif5But
+1yl+i+M8eq1/p/mD5t8rPspn1Ut/zOMTeYpjv1cP8ctfofhc8xfyUvml4ivF
+1/JGrjR/q3gt7+RG8/fyQfnXirc6j6N80vwbxTv5Vvm94nfyIN9r/iif5fSn
+fP5EnspXciHP5YW8lEt5Ja/ljVzJW7mWd5jrr/hePsjXcqt6R8VP8o3yO8Vv
+Fe/lO3nAPP8VH1X/LKc/5/kTeYqj/pVcyHPNXyi+xLz/Y57/yl8rfyNX8lbr
+1/JO9RvF95j3f9W/Vr+tfFT9k+rfqF6n+K3q9cq/U3+DfK/1R8XPqp/+kq8/
+wbHeVL6SC3kuLzDXX/FS8RXm9xQcn+82mPurqrfFs8tYa/4O8/u56u1V7/DQ
+z+XvWv228lH9nxS/Uf0Ox+fLW8V7zb9TfNB+7uVR9c+Kp7/m8QmeXcYpjvO5
+wvx7DRzf7+eqt1C9pVzKK9Vf4+h3o/wKx/2Hrfqplb9Tf432t1f8IF8rv1X8
+qPVOOL6/3mh/nfZ3q3o95vorPqife8zvHco/q7+0z/Mn8hTz/R/HeRc46s0x
+94twXI+l6pXyCnP9Md//VL/CcX9sq3q11t/huH/WKL6XD6p/rfVbHPdLj5j7
+VfKN+usw11/773W+d+pvUH/36mfU9Tqrn/S3vJ8J5v4P5vu/XGj+HEe/Cxzr
+LTH3z3HsZ4W5n6b5G9Wv5K3ya623U/1G8/c4Hh8H9Xet/bfyUedx0nneqL9O
+828V73H8fyd32s+g/u5xPB5GHPeHz8pPf49xdhknONafYp7/coHj96k5jvUW
+OM5zibn/h+N6rDDPf8z3P/VbKX+rejXm+suN9rvX/APm85/Wb1XvqPkn5d/o
+/Dqtf6v99Kp/p/xB532v+qPqnVUvvZ7nTzC/h76e519hfh/Dsb+55i+Uv8T8
+e3fVX6neWv1tVK9SfIv5vVnxndZrlL/H/HsEHK/P14q36ueo+ietf6P9dYrf
+qp9e+XeqPyh+r/mj4mddn/SPPD7BvP9jXv9xnEeB4zzmii8wn/+VX2q9lbyW
+N6pXqb+t4jXm/p/WbzR/r/M4KP9a+a3iR/mEuf7qp1P8VufXq5871R+Uf6/z
+GpV/Vv/pn3l8gvn3YDjqX2G+/+H4myu+0Pyl4qXWWyl/LW+UX6n/rerX8k71
+Gnmv/IN8rfxW6x8x7//Kv1G9TvFb7a9X/p3iw8P5X8Z75Y/yWfPTv/L4BMff
+FHP/F3P/B0f/c8zv5cpfPtS/jKXqr5S/Vv5G+ZW8lWvV26leI++Vf1C9a7nV
+eR3lk/JvtF6n+K3m9/KdPMj3qjfKZzn9O/cEc///wZe/K7mQ5/JCXv7f/wUv
+5wsR
+           "]]}, {
+          Hue[0.9060679774997897, 0.6, 0.6], 
+          Directive[
+           PointSize[0.002777777777777778], 
+           AbsoluteThickness[1.6], 
+           RGBColor[0.4286185, 0.2924847, 0.7194555]], 
+          LineBox[CompressedData["
+1:eJxd2zmw81YVwHENNC5dULyCQrxhGA/DMGY3u9gfW1BYzRJQIAGzJSZsDmER
+ARKzu3Sp8pUqXap0qdKlOlyqdMkwPn8z9+9G+X3n3HPuvVq8fF/e8N3nv/js
+a7Is+89rs+x/x+tr/HD8R5Ee8zhO4vimOE7jeB/H1+nP7+TXK4+6vKhD3zcq
+331nyn+z+rxF83ir6s3jyLrepvpvV/13yO9UvXep37tV7z3yQvnvVfx9mt/7
+lf8B5X9Q8/tQHNnnD8tFHGOfa0z9j6T9a0z9j6b9a8x+fCytV2PW83H1x9T/
+hOpj5vdJ1cf3cfyU6mP6P8Qx9qPG9P90HON6qjH1P6M45j76bNqvxsz/c5o/
+pv7nNR5z/p5Q/ycU/0Ic4z6pMfdFGce4rwrMfOQOc389GcfY3+LJNF7juB46
+zPq/mMYLucYxvw4z/kvqj+P81Zj+mPl/Oa1XYMbjuP46zPXzFY3H9zEex/no
+MP2/qvFyjWN9Heb8fk3jMf2/luZ3ys+WGo+53jD7h+n/9XQ9xdfT/Bqzf5j+
+30jjBaY/jvqdnH1T4zHjMfPHjP+W5o/Zf8z8lZ89FcfYj+KpNL+WO8zz8dtx
+jOutwNw/mPOH2b/vxDHWW2D2H7N/mPFVHON5lVdpvMDRv8L3UR/H/dlg9hvH
++gfVz55O8/On03iBY3yl/BrH+hsc6+lUb8Ccv++m9XPM80iu5BrfR3/MfuN4
+/g6Y++d7ab1cLnBcHxXm+lB+g2M/Osz6Fc+eSeeTY67HZ9L8CtNf8UbuMP0x
+1/+zaX6O6Y85/5j+ym/kTuMHzPX3/TSe47h+Csz+Y54vGt/IncYPmPX/QP3l
+ArP/itdyg7n/FB8w61+pP+Z5uErzK8z6Mft/8/XVyYOc/TAdn2P2H7N+udb4
+Ru5Ub5CzH6X1crnAXH84xteKNxrfyYPysx+n881vjj9VvML0V7xRvFN8UDz7
+ifrfHH+qeKV4rXgjd5j9Vzz7aRrP5UKuMP3lRu40fpCz59L55M+l8UKulF8r
+3sjdLf/6GuTs+TQ/lwu5kmscr0bu5EHO1qmnmPkoPle8ULyUK3mt8bW8U34j
+t3In9/Igj3L2s9RTOZfnciGXciWv5VreyY3cYq4vxXt5kEeNz15I49Obr8f8
+hTR/rvxCLuVK9daK16q/kxvlt3In9/Igj3L289RTzPWv+FzxQvFS8UrxtVzj
+eH/YYd5PbvnXY6vxnfr1ig+qPyqe/SIdP8V8HsDxeWKueIGjfilXmPMv1/JO
+4xscn0da9e80v171Bq1vvMXj9cs0f4r5PIC5/pVf4JhPKVc45reWa/XbqV+j
+fq3cyb3GD5rPKGe/SvOnmPXLc7nQ+BLzfQlHv7VcyzvVazDrlzv16xUf5FH9
+sl+nnso5Zv1ygePzcanxFeb6V36t+E7jG8Vb9e/kXh5w7M+o+tkm9RTz/MNx
+/83lQvml6lXKX2M+vyt/p3gjt3KHYz971RvUf8R8/3ox9fTFND9XfI65/5Vf
+Ytav/LXiNY7v3zv1a+RW/TqN7zHft5U/ytlv0vypnGPWj/m9S/ES831B9da3
++PVVY86/3Gh8q36d3OP4vXTQfEfVz16KY/x+NX0pzc9x9J9jfm9WvNT4CvP8
+w/x+ofyd4g3m+le8U/1e8xkw97+c/TYdP8U8/zHrlwuNL3HsZ4VjfWscf09X
+q99ObuRW9Toc+9HjWN+A43yNqpf9LvVUznGMnyteYM4/jvlUiq81vsZc/xrf
+aHyLWb/ye3x/PQ6a/6h62e/jyOcfzPWPuf/lAvP8wzz/5LVc45jPDvP+r/qt
+3Mk95v0P31+Po9ab/SGO3P+Y9WPe/xUvMNe/6lU4+q8x7/+qt8M8/1W/lTvN
+r9f4Qf1GxbM6rTeRpzj2907OcdSfafxc+Qu50PgHucSxvqVcqd9K49fK3yi/
+Vv4Wx/7sNH6P76/HRvUeVa+VD6rXyUfl9ziu1xPm/U3zPWO+7yh+kbM/pv0n
+8lS+w/w+gKPeTPlzHPuzULzAMd8H1S9Vf6n8SvVXGr9Wv43G14pvMfej+u9V
+v1G9R82nVf2D4p3qH2/1r69e/U7yoPpn1R81v4vGZy+n4yfy9OU0/+7m6yvH
+0W+m/Lm8wPx+Ij8ov9R8lupfqf9K49eqv5Fr1d9q/E75e8UbjX9UvNV8D3Kn
+/KP69co/KT4oflZ81Pwu6pf9KY1P5Kl8h7n/cfSb3eLX11xeyIX8oHql4ku5
+klcav1Z8o3it+FbeKX+v9TeKP2p8Kx+U3yl+lHvlnxQf5LM8yhc5+3PqiTyV
+7+RcnslzeSEX8oNcyku5klfyWt7INY793Sq+k/dyIz/efD22ih/kTv2Pci+f
+5EE+q/4oX+TsL6kn8lS+w/w+JM9u+dfjXPGF4gWO58uD8kt5KVfySvXWim+0
+nlreyjvNd6/6jfIf1a+VD6rX4Xj/Oireq99J9QbFz6o3qt5F+dkr6fwnr6T5
+U8XvMOdf8Rnm87/qLRQv5Ae5lJeYz/84Pj+tlL9WfKPxtfK38k7ea3yj+o/K
+b5V/0H502r+j3Gv8Sfs/qN9ZHuWLnL0ax/i+MZGnr6b5d3KOYz0zzO/Fyl9g
+fj/AfP7T+FL5S8z5V/4K83uT4hvVqzW/7W0919dO/fZyIz/KrXxQ/079j9qP
+XvGTPGh9Z52/UefnovHZNo1PMOcfx3zv5Fz5M8z3P8UX+P56LHCcrwfVLzH3
+P+b5r34rzN83aH0b1a+Vv1W/nfL3cqP1PeL499Wt1nfA/Hte7cdR9Xr1O8mD
+1n9Wv1H1LnL217T/5K9pfIqj3p3yc8VnmOc/5vcfzP2Pef+XS41fql+F4/e2
+lcav1W8j15rvVvGd4nvNp5EftT+t5ntQvFP9o/r3qn+SB9U/Kz4qfpGzv6X9
+Jpj3fxzXw52c49j/GY7/j2aOZ9fjAvP7H+b9X/kljvtpqf4Vvr8eV6q/Vv2N
+4jWO/diq3k7eY57/2r9H1W9x3O8HxTv5qPn0qn/S+Rm0H2f1GzX+ovlnf0/7
+TXDMZ4p5/mPe/5U/U/5c+QvlF/KDxpc41reUK3mlemutb4P5/KfxW813J+/l
+BvP9X/Vb5R80v04+av296p0w51/1z6o3avxF+dk/4sjnP8z5x5x/Ocf8/ifP
+MZ//Mb//qf+D6pfyEvP5T/VWqrfW+I3G15rfVuN3Gr+/5V9fjeo9ql6r+EH7
+06n+Ufm96p2UP8hn1R9V76J49s84xvmeYP49EOb3P8z9L8+UP5cXmO//8sPN
+11ep+BLz74tUf6X5rzV+o/xa8a3q71RvLzfyo+q16ndQvJOPqtfLJ9UbNP6s
++ChfVC/7V+qJPMWcfznHfP/T+LnyF3Kh/Ae5vNW/vpaKV+q/ktfK3yheK76V
+d5rvXvNp5EeNbxU/yJ181PhePsmDxp/lUb7I2b9TT+TpzdfjneK5PJPn8uL/
+/i+ugPv2
+           "]]}, {
+          Hue[0.1421359549995791, 0.6, 0.6], 
+          Directive[
+           PointSize[0.002777777777777778], 
+           AbsoluteThickness[1.6], 
+           RGBColor[0.563821, 0.527565, 0.909499]], 
+          LineBox[CompressedData["
+1:eJxd2zmw61YZwHENNC5VULigEB4m42EYxuxmjdiC2U3YzC4ehJgE8sxuAgGF
+BDBLgkuXKl26dKnSpUuX6nCp0iXD+Ptf5vxvc+b3vu98Z5Fsy+fe95ZHj59+
+5g1Zlv3njVn2v/b+0z+ZtlmZehB+c7R5tE9E+6Zoi2iHyqcdKe9t+nf6vVX9
+ntC/j9W6zttV7x2qM1H9d2pe79J471b8PdGy7vdq/Pcp//0abyp/IFr29YOq
+9yHV+7DiH9F8P6r6Tyq/jDb2o8bs58eijX2tMev9eLRxX9SY+X0idY25Hp9M
+XWOu46fS+dSY6/aU4k8p/ulo4z6o5WyWjldj7oPPKI7Z389GO4o45v76XLSs
+D3M9Ph8t+4OjXvYFxTH1v5i6xtT/ksbHXN95tLFfJY711/M0v8Vcny+n8RIz
+Ho71tJj74+lo43VWYq4XjvW1mOv7lTS/xPG6rDH9Mdfvq+qPud445tti9u9r
+ab0SM38c9VrM/f/1tH4p15j9x+z/N1KXmPsBx/62eBTtQv0x42P2D7P+b6b1
+Ssz6cVyvFnP/fit1iaNeLbeY8b+t+eO4HrXcytl31B/HfGvFW8z9+910fiXm
+/Uhu5ex70XL/4ficqjHzx1z/76fxEjM+jnqt8rMqHb+QSxz1KrnGcf0axVsc
+8+3k7AcaH7MeHO9nFeb9RfFGbuUOs/+PNP6jNF7imE+FGR/H53Wj/FbuMPf/
+D1MXmPcDPIrx5RrH53GD4/O4xTG/Tv2zH6UuMOPjqF9hPu8Vb3A8N7aY8TGf
+T89ofBz7Wype4RivxrG/Deb6q16nePbjaGO9hVzi6F8pXiveYMZXvMM8Rz+b
+ung2zS/lCrN+zPqV32Lufzlbpi4w78d4FONj1o9ZP475tYp3mPX/JHWBo38p
+V3KNef0r3mLuP42XPRdtfL8pnkvjpVzJNY77vcGML3fqnz2fzq94Po2XOOZX
+ybX6N5jxVa9TPPtpGi/kEsf6KsVrHPNplN8qv5Ozn6XzKeQSx/oqzPrlRm7l
+DvO99oU0XryQxkvFK8VrxRu5VX6HWf/jNF7I5eM0v1K8lhvM+A/x+0+neLZK
+++dyIU9w9C8Vnz/4/lPJK7lWva3ijXyQW/ksd3IvZz9PncuFPJFLeS5X8kqu
+5a3c4Nifg+KtfJY7uZezX6T1c7mQJ3Ipz+VKXmHeP3D8bJXfPMTv7UFulX+W
+O43XK579Mh0/lwvM+uXyIf/ezhWvVG8l1/JWblT/gHm+U/yM+bxTvMe8//8q
+rZdjPo8Un2Den5Q/V7xSfIV5fpa36t/IB9Vr5bPm2+FYb6/87Ndpfi4XOPpP
+cPQv5bn6V/IK8/6t+Fb1GsUPirea31n5ncbrlZ/9JtrY/1wu5Anm8xmzfsUr
+HM+LK7nG8fy6lRv5gEf3tlX8LHfK7zHPv79NnWO+D8gTuVT/OeZ5XfkrzPmE
+4lvM/a/6B8zznXyWO9XvNX62Tuebr9P8QvEJjvmUyp8rXuEYb4U5n8Kje7tV
+fqP6B7nFvP4V7xTvNb/sd6lzzPMojvlNlF/i2J855rwAx3nCCrN+1d+qfoNZ
+v/Jb+azxO/XvVT97MdpYb/5iml/g2L8JjvFKeY65/jjWu1J+rfG2ciMfMOdL
+8ln1OxzneT3m90C/T+eX4zifKnCcD00w50M46s3lSl7JtcbfYtaP4/46YM4X
+8OjenjW/Tuvp5ewP6fg5jnqF4hPM+jHrlysc+7fCnK/iOJ/eYtYvHzDnG4qf
+Nd9O7jW/7KV0fvlLaX4hT+QSx37MMe//mPc/zO8XMPc/Ht3bRv0Pirc47oez
+8ju51/yzP6b1cszzD476E+WXmPd/zPoxr3/M+TGO/d8q3mi8g/JbzOe/+nea
+Ty9nf0rnn+PoX2Be/5jfF+BY31yuVG+leI15/sGje9soflC8Vf2z1tMpv1e9
+rE7jAznH8fkwxHw+4Lg/xpjXi/Knql+q/kz15spfyJXyl/IKx3rX6l9rfhv1
+32o9O+U3iu9V/4DjfjtqPq3yT5jnGY130fw6+ar8XvGb4tnL6fiDl9N4jqP/
+UC5wXL8x5nlRnqp+Kc8w3ydwvB8tVK9S/lLxleqvNf9a+Rt5q/o7zPMpjtff
+HvN9Vftz1H63ip8UP2v9F7nT/K4av1f9m/pnf049wFEvx1FvKBcPvv+M1X+C
+uf6Y52fFZ5rPXF7IleazxLHeleazVv9a8Y28Vf5O9RuNv1f/A+b1r3qt+p9U
+/6z8i+Kd+l9xnD/1it/k7JW0/uCVNJ7LQ7lQ/7HiE3kql/IMc54oL+Tqof/9
+Zymv5LVcq95G3ip/Jzda/17xg3yUW/kkn+WL5tfJV7lX/5ucvZrmD+T81TR/
+KBfyWJ7IU9Uv5Zk8V/+FXMlLeSWv5VreyFt5JzfyXj7IR7mVT1r/+SF+by+K
+dzjuvyvmvFP9b+qf/SX1AMdPLg+VXyg+lifyVP1LefaQf2/nON5PF3Kl/KXG
+Wym+lmt5o/5bzW+n/Abz+pcPyj+qfqv6J/U/yxfM85/244q5/sq/YZ7//hpt
+fD4NMOfhmOd/zPXHsb6x4hP1n6p+Kc8wz3+KL1SvUv5S8ZXia623Vv4Gj+7t
+Fsf+7dS/kffyQfWPmPNL+aTxzlr/RfU7re8q98q/aT7Z31IPMM//eHRvh5jz
+EcXHmOc/HOuZKr/E8Tw90/hzeYF5/tf8l6q/Uv015vxB3ih/q/F3Wn+j8faq
+d8BxXnBU/1bjnRQ/4zh/uKhep/gVx9+p94rftJ5sk9YbYM7DcVzPIeZ8XPlj
+HOuZYJ7/5VLjz3D8/fFc8QUe3dsKx34t5ZX6r9W/1vw3mPM45e+0vkbeY64/
+jv0/Kt7iOA89ab5n5V80v07zuyq/V/5N+5P9PR1/gOM8Nscx/yGO9RaY7/+Y
+7/+KT9W/VP2ZPFf+AnO+pvwl5rwdx36sMb9/xFx/zO9jtZ4dHt3bRvX28kH5
+R62n1XxPip/V/6L1d1r/Vevt1f+m+tk/0noDzPs/jvUPFS/Uf4zjfprg+H8w
+Uxz/D6bE8f9cZjjuvzmOv+df4Hh/qHCsZ4lH93al/DXm/F3z38hb1dthfj+H
+4/1xr/06aH5H1W9V/4T5/i9fVK/TeFddn17rvWF+//HPND7A/D4Ix/yGihc4
+rvdY+RPM5z/m9a96M9Wb47ifFzjWV2E+/zHnfxp/jfn/CZrvRvux1fg71W/k
+vcY7aL5H5beKn+Sz9uuieKd6V8V7zf+m+WX/SvsP5Bzz/I+5/jj2a4xjvIn6
+TzF/P6PxZpjnP8UX6l9hzv/llfqvMed/8kbe4tG93Wl+jfL3mPNfHN+Hjoq3
+6n/CvP9r/y7K77QfV623V/ym+WevpfmD19J4jnn+wzz/yWPlTxSfKl4qPlN8
+rvgCc/6r+S81/xXm9a96teptNP5W/XeKN+q/lw/yUW7lk+Z3xpz/yJ18lXv5
+pvGy16Pl/Of1NJ7LQ7nAXH95ovwp5vpjXv+Kz9V/gWM9lea/VHylemvVq+WN
+6m0f6t1/dqrfyHv5oHpH1Wvlk3yWL3InX+Ve49/k7N9p/kDO5eGD720hj+WJ
++k//7/8C0yMAWw==
+           "]]}, {
+          Hue[0.37820393249936934`, 0.6, 0.6], 
+          Directive[
+           PointSize[0.002777777777777778], 
+           AbsoluteThickness[1.6], 
+           RGBColor[0.663226, 0.6872815, 0.9117649999999999]], 
+          LineBox[CompressedData["
+1:eJxd2zuQ81YVwHENNC5dULigEDsM42EYRrzNM+K9vBIRAiwEghIILBASAQk4
+4RFBICwQiEuXKl26dKnSpcot1eFSpUuG8fkvc//b3Pl9595zz72SbEv2945n
+Xnj82bdkWfaft2bZ/9rL3/RI2mZl6lmZtnO1b5MX+ve3K54rfqX2nYq/S14q
+37s173uU772at9A871P8/cr/Ac3/QflD6v9h1fMR9V/JH1W9H1P849Gyj59Q
+/k+q/k/Jj6i+Mp2vxezHpxXHHIfPRBvHocXU89k0X4sZ/zmNx6zv86lbTP4v
+KI7Zry9GG+ttMefNtcZj9utL0cZ508rZl6ON867F7N9Xor2KOKb+r0Yb+9Fi
+6vua4pj8j6b52kfT/tljqv8xxato4zoocZzXLY7zuMes/+vRxvpLucVx3fSK
+Z4+n6ynlFsf6eszx+Ybmx5xPOPL1mPqfiPYqxj+R9m9x5Osx1883VT+O86+V
+exzzZd9K85dyi2O9PWb/vq36MfXLPeb8uknzlzjytTiuj179s+9EG6+zJeZ8
+xJGvx5x/3402jkeJ43W3VbzH1P9ktBz/J9P+LWZ+TP3fS+st5RYzP+Z95fup
+S8z+Y+bHzP9UtLEf5VNpvMWxHz3m+v9B6hJz/ijeY86fOp0vx3G+lnXav8a8
+Hql/h69iPhznz6h49nRaX/50Gi8VrzH7gyN/h3m9wHG9jsqfPZM6x+wnjv2s
+FW9x7E+n/j2OekbM+9sP0/pyzPw41lvLLY7zr9P4HrP/imc/ijZe/3PM9YRj
+fI15fcNXMT/m9UrxEXP9PhttnE855nqUa7mVO8z8ONYz4qgn+3HqHMfn3hLH
+emscn39bHMevk3v1HzHX/0/S+nO5xFFPjTn+mOtP8R5fxfyY6/82WvYfR/0l
+5vzDnP/q3ylfjzn/5eynqXMc51upeI3Zf7mTe+UblS/7WbSxfzmO8SVm/zHn
+n8Z36t8r36jx2c81v1zKNY78LWb/MetX/1Hx7Lk0nuO43yufS/vXmOsfM7/c
+a/woZ79I58sx1x+OfDVmfsU7zPqVb1Q8e17zP5/2LzHzK94q3sn9Q//L36jx
+2Qupc7mUa7nFUX8n9/IoZ03quZzj+CsULx/il7aSa/Vv5Fb9N3KHYz/3ivfK
+N8ijPGk92S9Tz+VcLuRSruRabuRW3sidvJd7eZBHeZKzX6Wey7lcyKVcyTXm
++Mstjutxo3infHu5V/9B8VGeHhztr9PxcznH8VcoXipeYV4v1b956H9pW3mj
+/p3ie8z9JI7rY1A9ozwpf/ZiOn7+Yto/x7GeQi5x5KsUrxVvlL9VfIN5P1V9
+e+XvH/Jd2kHxUfknxbOX0vHzl9J4juP9upBLja80vsaxngbzvEneaHyHo/69
+5usVHzTfqHyT4tlvUs8x9yP46tIWmOOPYz8qja+Vv5FbeYO5n5P3mM+3ig+K
+j8o/KZ79No3PMcdf8ULxEsd6K/WvcexPg7n+Mccfx+fnDke9e8z9ncYP6j9q
+/kn1Z+t0/HydxnMc9RaY1z/M+uUas358dWlbxTeY6x+zftXb49ivQeNHHPeb
+k+bLXk7rmePIn7+c9i8w9+caX8m13OC4325x1L/Bsd5O9ewV71XPoPgoT5ov
+eyXa2J/5K2n/HMf9YqH+JY58FeZ5gdyofytvNH+n8XvM+5/iA766tCOO/Zm0
+nux3qec4nqfkOJ7/FTi+JypxzFdhnhcpX4M5/uq/0Xyd6ttj1o85/qpnVL5J
+8ez3af45jnpyucC8/+HY/wrz+odjvgZz/JV/g1k/jvXtla/X+AFz/uN4fjop
+f/aHaOP4zHF8X5HjmL/APK+VK+Wrcexvg6P+Vvk3mPNf/feY55saP2Cedyg+
+ydkf0/5zzPMIucAcfxz1VTj2t8axngZz/DHHX+M7zPmvfL08aD2j6ps0f/Zq
+mn/+ato/x5G/wKwfx35WyldrfCO3yrdRvk717NW/x3z+1/hRnjCf/9poY79m
+OPLPcdS7kHN5iaPeQl7JJY7jca16KvW/UX21+t/i+PzSKL7WfK18h+P4bTR+
+q3o6HPu7w3H97xU/qP5e8aP2c1D8Hsf1MsonzOu91nNW/dmfoo3zZ4Y5/jjW
+v8AxPscx/1L9CxzrWWE+P6v/tVxp/A2Oz581jvP5Vvkbxddab6v4neIbrW+r
++jrNt9P+7NX/IPfyUR5Uz73qHXW8TopP2r+z+md/Tueb4VjPHEe+hfrnmOtf
+8QLH/cNK+UrNd425n5RvNL7GsT+3+OrSNuq/1nyt6rtTfCNv5Q7H+bhTPXv1
+PyjeK36UB/le9Y6KnxSf5LOcvZbWP3stjc8VX2DuD9V/qf6FvJJL+foh3+Wv
+UvxG89fyrfo3qm+teCvfaf6NvFX/TvGd6tmr/0HuNf6oegf1v5dH+aR8k+Jn
+xbO/pJ7Jc3kh5/JSLuSVXMrXciXfYF7/5Vu50fi13Mp38kbeyp28k/eq56B4
+Lx/lQb5XvlHx04Mv7SSf5eyvqWfyHHP9y7n6LzHPi3G83q00vlT8Wq4e8l/+
+bpS/lm/lRvWtlb/FvP/LG/XfKn+n/DvF94of5F7rO2p/BsXv5VH1nTDP++Sz
++mevRxvrnWG+D3k97b/AfF8pL9W/wLEfK8VL+VquVN8N5vO/8t9injcp31r9
+W/W/03o26r9Vvk79d4rvVe9B8/Xa76PWO+D4fHWv+UbVd1K+SfWcNT77W1rf
+DPM8XPEF5v4Px/3JEl9d2gLH/dBK8RJz/ydX8o3mr1XvreptMMcf8/wdc/wx
+zyOUf6t8nerZaf69fNB6eu3fUfMNGn+v+UfVf1L/ST6rf3aXzjfDV5d2jrn/
+x3z+l5fKVyjfCvP8XPFr5aswx1/ja/W/lRvlX2N+H6l8dzjO1436b+VO9e0w
+z6s0/0Hz9Rp/xHH/Pqiee61vVL6T4pPqOWu+7O9pfTMcx3uOY70LzO81FV/K
+BY75Vpjfd+Go71rxSuNvNH+t+m/Vv8HxvH2NYz9bjb+TNziun63yd9qvHY7z
+f6/5Durfaz1HrX+Q79V/lE/a/0k+a33ZP9L6Zjj2a47j+Cww3w9gXv8x35dp
+/ErzlfI1jv9HU2He/zVfrXpuNV+j/GvM8z/F7xTfyFu50/id6tmr/0H19Zjn
+P1rfoPH3Gj9qvhO+urST8p+1n9k/0/wzHOPnONa3wPH9V46jnqX6F/JKLnGs
+91rzVzjOxxsc/x+lVv23mNd/eY35/SaO/buTN1rfVvk6zb9TfK/1HOQex+vB
+UfUNyn8vj9q/kzwp/1nO3kjrnWG+D34j7b/APP/BfP5XvgLz+o/5fbni15qv
+wjz/wzz/wzz/U30Njv1Ya3yr8XeY3yNp/q36d8q3k/fyQfX1ih/lQft5r/io
++EnxSfWeNX/2r3R9M8z7P+b9X/1zeYn5/Kf4Si7la42vcNR/g/l9Aeb+T+Mb
+jV9rfKv+d5j7P43fan86xXeqZy8fNF+v9R/Vf8B8/6P5Rvmk8ZN8xvz+799p
+fIa5/8OxHwv1z3HkW6p/ofhK+UvM9z/KX6n/Deb3RZrvVm7kteppNd+dvNH4
+reKd4rsHX/72ih80vtd6jooPynev+Kj8J61vUvwsZ2+m/Wfy/M20/wJz/B/i
+l7+lXCjf6v/+L6o5C3U=
+           "]]}, {
+          Hue[0.6142719099991583, 0.6, 0.6], 
+          Directive[
+           PointSize[0.002777777777777778], 
+           AbsoluteThickness[1.6], 
+           RGBColor[0.762631, 0.846998, 0.914031]], 
+          LineBox[CompressedData["
+1:eJxd2zuw61YVgGENNC5dULigEGcY5gzDMOZtnhEEEgcImBDAkAAiEGJCIA4Q
+YiCAeATMK7h0qdKlSpcqXap0qQ6XKl0yjNd/mP2fZs9319pb+yVZkn3f8dzL
+Tz3/lizL/vPWLPtfefsbHsnSvyL995E8LtJ/f1uR/vskyrervIsylylp751q
+511q517//m79+3vU7nt13KnqvU/136/2P6D8Dyr/Q8r/sPI/ovgsSsb5UcU/
+Jn9c/kSUjOuT8qeU/4j6W6THr+Ts01HGPFaY9j8TZYyvwhzv0fR41aNpfvbZ
+tL0KM8+fS11h1uUx1X8szc8ejzLWtXo8zc/mis8VfyJKxv+E4p+PMtaxkrMv
+KI7ZF19Mx1Nh9tGTqv+k4l+KMvZhJWdfjpLxYc6LRTqeAkf7FY592WL2yVdS
+Fzj2YYWjvRazPk9FGedh8VSaX+E4D1o5+2qUMd4Cs19wjL/FrN/TUcZ+LHD0
+p3o6zW8x8/u1tP0Cc3wc691izvOvRxnjLTDrKbeY+fuGjo/ZL5j5x8zfMu1P
+gakvt5j9+80oY/8WmPnDzB9m/30rdYGpjxk/ZvzPpP0rnknjFWb8mPV7Nkrm
+79k0v8IxvlbOvp26wPQfx3W/xZy/30n7W+BYnwozfuVn31V9zPUKM/+Yz70y
+7V+O2Y845qfEsf4Vjvmv1V6r9no5+17aXo5ZT7mUKxzt1ZjzHcf89ZjxP5fm
+58+l8QLHfJaY8Steyy2O+egx4/9+2l6OuR5jxo+5nuPYfzVmv+MYTy9nP4gy
+rn85Zj/j2F8lZvxyrfwWx3z0mOvv82l+Lhc41q9UvMKsP47xtfgujo+5P/lh
+6hwzfhzzU2LOL8VrzPHVfo+jP9kLUcb9aP5CGi9w3I+VOO5/K9WvVb+Ve9XP
+Vmk8x3weyiVm/DjGWyve4tivvZz9KMrYDznm80DxUvEKx/zWOOarxTG+HjP+
+F9P8/MU0v3gxzS9xPI9UmPnHMV+t6veY/ffjKOP+OMfRn0LxUq5w9KfGcbxW
+7jHPPy+lzl9K8wu5xPGcV+G7OD6O/rSq38vZT3R8HO0XOJ4HSxzPlxWO59Ra
++a3a61U/+2nqXC5w1C/lSvm13OKYj17x7OW0vfzlNF4oXsoVZv3lVvm92s/W
+Ucb8jeUcx3xO5UL5C7lU/lrx6sG3v51cy43qt3In9zjeVwyKZ6+kHr+S5ufy
+9CE/askLuZTXciXv5Fpu5Fbu5F4e5OxnqcdyLk/lQl7IpbyWK3kn1w++lY3i
+rdwpv5cHOft5lLG+Yxx/ueJTuZAXql8++Fau5QrH+bHDcb7Wym/Ufqt4p/q9
+PMjZL6KM68FYznG0P5ULeaH6JY7r0Rpz/6L4DjN+xRvVbxXvFO/lQc5ejTI+
+f8Y42stfTfOn+O5WFvICc7+i9tfKr+Qd5n5GbpTfqr8djvnv5UHOfpn2b4xj
+vLk8xdwf4rgfW+C4HyyVv5YrHPO1w4xf+Y2O1yq/k3vVHzDvP19Ljz9+LY3n
+ONqbYu7P8N2tXGDulzDrr/qVjrfDPE/Kjeq36l+neK/+DepPtknzx5s0nuPo
+3xTzfIxZf+WXam+Noz+V8neY9cexPo3qt8rvNJ5eHpSf/Sr1GPM8jON5c4p5
+PpQXmPHLax2vwux/ucasv47X4nj+7XA8j/c4vicYMO+nf516LOeY8WOez3A8
+ny9w9K/EsV/Wildqb4cZP767lQ2O+WsV73CsX49j/gfM8+dvoozxjTHvw+Sp
+XOB4X7fAsR4ljvGu5Urt7VS/VvsN5n08jvnt1H6PY7yDnL0eJfsfx3rkr6f5
+Uxz7qcDR3wVm/RVfY96P4pj/HY79VOPYj43aaxXvMPtf/R/UfvbbKGP+xzjm
+N8fxvdtULpS/UHslZvxyhRk/5n2K3GDOf9Xv1H6PY7yD4tnv0vgYx37Lcczn
+VC4w6495X4zZ/3Il71S/Vv8azPs1ucO8b8RxPRkw3z/+Pq0/xrwPlqdygbn+
+qb1SXqt+hWP+dpjPf8z9j+ItjvF1mPsfecDc/1ZRxufjCMfxxvIEx3hyxe/l
+KY7+znD0p1B7c8x84ji/lpj30Tj2zwrH/K5xzM9G/akU36r/O7W/V/9q9f+g
+9hu1d9TxWsVPaq9T/Kz56xW/yIPau6r/2R+ijPkcyWPM+mM+H3C0f6/8KY7x
+zuQCx3jmqr/A8fm9VP1S+Svlr+WN6lfq/xbH/tnJex2vVv2D2m/ko/JbtXeS
+O3x3K8+ar175F413UP5V7WV/TOMjzPmPo72J4jmO+/t7HO1PcVxfZsov5Lnq
+LxRf6vil+r/CcX1bK3+j/Ereqr879Wev9mvFD4o3OObvqHir+icc4+3ks+r3
+OJ7/L2pvUP5V+dmfUo/ksTzB8b4ql+8x74vkmVzIc7W3kJc43reV8kr5a3kj
+V/JW3uF4X7LX8WrFDxpPo/aOqt/Kp4f6t79O8bPiveIXeVB/rnL259QjzPtQ
+xSdyrvz7h/jtbyrPlF/Ic3khL9VeKa/ktepvFK/krbyT93ItH+RGxz/KrfJP
+cief5V6+yIPW64r5feUbaf7ojTQ+licP+bcyx6y/8qfyTPULxeeKLxRfyiWO
+98UrzPsmHNfzjeIVjuvjVt6p/b3itXxQ/xrVP2K+H1T8pHin9s6K95qvizyo
+/hVz/f9L6hGO/ozlCeb3EpjPfxz9m6r9meKF2p/LC3kpl2p/pfbXONZnI1fy
+FnP/j2P/7JVfK37QfDTq31FulX+SO/ks91qPi/o3aD6uOn7219QjfHcrxzja
+m2C+r8asP+Z9MY7+zTD3/4rPFV/guF9eYn4PheN5ZYV5/sPxvLNRfqXjbzH3
+fzj2w17jq5V/0Pw1ih91vFbze9LxOvms+ejV3kXHH7S+V+Vn27R/o20aHys+
+wTz/45jve3mKef7DvD/GMZ9zeYFj/EvM78HU/grzvg3Hftlgfl+p/K36v5P3
+Gn+t+EHxRvEj5v2d+n/S/HTKP8s9jv18kQf5quNlf0s9wnH8Meb5H/N7PRzv
+Z+5xzPcUx/vQGeb9IY7xzBVfyEvM+zX1b6X21srfqD+V2t8qvsOxX/aY9z/y
+QcdvMOsvt8o/aT479e+s/vVav4vmY1D/rjpe9vcoY71HmOd/HNeDCeb3eqp/
+jzn/1d5M9QvM+qv+Asf/J1ji+P6hxDE/Kxz7b425/mPWX8ffKn+n9vfKr5V/
+wLF+DY7z5ajxtervSe11mq8z5vqv/Is8qD9XxbN/pO2NMOe/PFF+rvg95vtC
+eab6BY71mMsLzPUfx34sMeuP43xd41ivDeb/V8hb5e8w13/1r1b9g9xovEfF
+Wx3vpPwOx+fhWfPRyxf1d5CvmOv/P6Pk8x/f3coxjvoTHP3NMe9/cbQ/xZz/
+mPf/yp9jfk+Aef+r/FLxlY63xnF/utH4KvVnK+9w3D/tFa8xz3+KNzr+UfFW
+9U+KdxrfWePrFb9o/gbFr3L2r7R/I8zvQTD3/4rnmO9/cOyPKeb7H7lQe3PM
+/Z+8VH6p+Er9WcsbjadSe1v1b4djPfb47lbWav+geKP6R8zzH47ns5Pqdzie
+t86K91q/i+KDfFV+9mbanxHm/c+baf4ER3u56t/j6O9U8ZniBY7xz3Gsz0L1
+l3Kp/q1Uf638jfIrzPprfDvl7+Va7R80vkbzeZRbjf+keKf2zsrvFb8oPshX
+zPvff6ceyWN5gvl9NOb9vzyVZ/+v/1+7TBgq
+           "]]}, {
+          Hue[0.8503398874989481, 0.6, 0.6], 
+          Directive[
+           PointSize[0.002777777777777778], 
+           AbsoluteThickness[1.6], 
+           RGBColor[0.8519034999999999, 0.876768, 0.874037]], 
+          LineBox[CompressedData["
+1:eJx12z2w60YVwHENNC5dULigEHcYxsMwjIEA5jPiK1y+TSDBgRBEIMGQkBgS
+giEBRPiIgQAqXap0qdKlSpcuXarDpUqXDOPzf8z+Z/Kand87Z3fPrmRfae97
+73r6xUefeVuWZf95e5b9r739GR6+tZ8p4i+i/XC0o2gfinYc7YeifUe0s2gn
+0b472neqzaO9U/se9Xu//v6D0U6jfa9axnnfW4xDnDoZ5wNvMQ/jsk76P6R8
+9on5PiJ/VHXN1f9jyv+46v6E6v6k5v2U8j6tuh9W/UU6X4Wph/sg1l/J2Wej
+jfVUmHo+F23sU4VZ9+cVl7MvKI5Z/yPRxr5Wjyj+xWhj/RWmvvto4zpXmP5f
+Sl1hrt+XNT7mPvpKml9hrudXNb+cfU3jY+6jr6euMOv7RrSx3xXmflhEG/tb
+LNJ4hWO8Ts6+mdZbYK4Xjvo6TP9Ho439Kh5N4xWO/e8w98e31B/THzM/Zn+/
+nY5f4Bivwqwfs3+PRRuf8+KxNL9SvFM8ezx18XiaX+Got8Os/zupC7nCzI+p
+fxkt+4fpL3eYz+8T0cb3VIHje6x6Is3vMN9P31V/zP5h1q949r00XmCun9xh
+9u/JaGM/iifTeIW5/pjP9/ejjfurwPRXvMOs/ynVj/m+ULzDfD/9IFruPxzf
+LxXm+slZGW2sP8fcj2WaX2K+D3HU1yje4bj+Peb774fRxnpzzOcRMz/m+wlH
+vY3cyT1m/qfT+nMczwMFjp+HJWZ+HPdDo/E6HD8ve8z8P4qW9WPml0sc9VSK
+N3In95j758dpfblc4Fhfibk/FW/kTuP1mPU/kzrHfB4w8yu/wrGeBsd8ndxj
+nm+eTeP5s2m8ULzE3P846mlwPE91mP1XPPuJ5sfc/4qXilc4Ph8N5v7DsX+9
++mertJ4cx/N5geM5vlS8wncxP4796zDrVzz7qebHMV6BY74SRz0VjveIRvFO
+4/dy9jPNLxeY9eOYr5IbuVP/HvOe9Fy08R6VP5fmF/gu5sfsv+KN+nc43tt6
+zPzPp/n582l+IZc46q0Ub+RO7uXs59HGe2YuFzjeS0vFKxz1NMrvlN9j5n9B
+87+Qxgsc+1XKlfIbHPV0ci9nL6bj5S+m8UIuccxXyY3yO8z6Me/5a+LRbZ3G
+c3mm/EJeKL98EL+1a8Ur9a/lRm7lTj7JvTzI2S9Sj+VcnsmFvJBLeY1Z/4P4
+ra2V3yi/VX4nn+Re/QfFs1+m843lHHP95eJB/q1dqH+p/LVcybXcaPwW8/2i
++Enu5QHz+XspHW/8UpqfyzPlF/JC+aXia8z3B456armRW43XySe513yDnL0c
+bXz/j3H0z19O82eY7yd5gVk/jp+Ha3x3ayvNXyveKN7KneY/Kd6r/gHz8/9X
+6XxjHM8rueIzucDx83ghlzjmW6t/heN5qMbxfN0o3mKeL+ST3MuD6sleSccf
+v5Lm54rP5AKzfhzjl/ju1q4xz2+K1xq/0Xit3Cn/hGP/ehzPzwPmvPfXqcc4
+xstx7MdMLnDUs8C8r2j8Nb67tRWO+mrM9Vf/Vvmd8k84nv97xQf1zzbRxvvA
+GMf7co5jPTO5UP+FXGLWj+9ubYVj/2rM+xSO95tW7lTPSfX3OPZj0PjZb1KP
+cYyX43jfnyle4Bh/gWO/S42/VrzS+DXmfRbH9Wox53nqf8KxPz2O/RgUz36b
+9h/LOY75ZpjzAcz1l0sc+7XGnI9pvhpznqT8Fsf5YofjfOkk9zjOFwfM+dur
+aXyM47wufzXNn2Hez+UFjv0ucdSzVrzCsb4ax3406t8qv1N9JxzXq8fc/5jz
+y9fS+cavpfn5a2n+DHM+qPwFjv0rFV9j7n8c17NW/wbH9WmV3+HYjxNm/eo/
+qP7sd6nHOMbPcez/TPkFjvkWmPNKea3xK8Vrjddo/hZznoz5/sPxfdPjuD8H
+zPn/79P5xpjvP8VnOOopcNS/wDF+iWP+tVzJNebzL7fK73Cs9yT3qm9Q/dkf
+0vHHmPNYzP2P+X0B5vrjmL/UeGu5wvz8x3z/a/5W/Tvln5Tfa/xB+VkVbezP
+CMf+jBWfyDmO/Zhi9kvxufoXOPb/Hke9C3mp8Ut5pfHWONa7UT0Vjv3carwa
+x+d9h3k+UX17zPOaxj+ovg7H8+ZRPqn/WfEex/PTRfUNqu+q/OyP0d7d2hHm
+fUCeKD/Hsd4pjvlm6j9XvMBRz728kJear1Q9K+Wvlb9RfoXj/WWreI3jfWWH
+Oe+V91pvq3oOcqf5jpjneeWfVU+v+S8ab1D+Vc5ejzbWP3o9jY9xvF9PlJ/L
+U8z7ksaby4V8Ly/w3a1dYn4fp/lXmPMWjbdRfqX8rfJrHOcHO8Ub9d9jzmvk
+g/p3Gv+o8U6KnzVer/yL8gf5ijn/+1PqEY7zt7E8UX6u+FTxGY765jjqKRS/
+V/+FvJRLzb9SfK3xN4pX8lau5d0D3/40mn+veCsf5E79j4qf5LPye8Uv8iBf
+5ezPqUfyWJ7IuTyVZzjqnSteyPfyQl7KpcZfKb5WfCNXyt/KtbxT/0bey618
+eDDere1w3J9H+SSfMZ9/jXeRB/mq8bK/pB7hGH8sT+Qcx+d5Ks+UP5cLzPe/
+vFB9S7mUV5jfNyi+0fyVvFV+rfXs5Eb17nH8/Gvlg+brcPw8Oir/pPHPmN9n
+q/9FHjTfVc7+ms43wvz8lydyLk813gzz/Ifvbm2h+D2O59eF4kvM+bLGW+FY
+/1r9N5h/z6r+W7lW/g7z7200/l7xVvGDxu9U71Hxk/qf5V75F+3foPwr5v3v
+jWjjfWT0Rhof4xhvonguTzHvfzj2b47j+bZQ/r3GW+B4X1sqv8RxP6ww582a
+b6N6KuVvFa+1/p3Ga1TfHnNeqfUcNH6n8Y4a7ySf1b9X/4v2Z9D8V60n26bj
+jzDnQTjefyeY66/+U8VnOOqbY87P1f8ec56E47xrqfwSx/27wpy3qv6NXGm8
+reqvVe9O9TSaf6/+rfIPWl+n/KPGO6m+s+K9fJEHrfcqZ39L1zeSxzjmn2B+
+P4RjPVMc653huB5z5Rca7x5znqb8pVziuJ9Xqnet9WwUrzT/Vvm15tvJjda7
+x3G+2+I4fz5ofZ3254g5z8dxf5xVb6/5LqpnUP5Vzv6e5o8wvw/B8f9MJmH+
+n0dOPP7fyRRzXoxjv+Y46i0w1x/H9VkovsT8fkn1rjC/b8LxedjIlerbavxa
+9eyU32j/9oq3queg8Tsc9+9R453U/6z97RW/aPwBx/111fXK/pHGR5jfh2A+
+/5jzXxzzT3Hs70zjz3Gst8Cc/2HOfzX/EnP9Nd9K9a/Vf4M5f1c9W8VrrW+n
++Rrtx175reo9KL9TfUfVf8LxeTlrvF7jXTCff+Vftd7szWhjv0dvpvExjv2Y
+YP59DI7ny6nGm2m8Oeb3p8q/13wLxZfqX8or5a9V30bjV5jPv/rXOO7Pndwo
+f696Wu3XQfN3qu+o8U747taeNX+POf/FvP9p/Cvm33/9M9p4fxvhmG8sTzDn
+v4pP5RmO+uaKF5j3P+Uv5KVcqv6VvFa9G/Wv5K361+q/U36j+F79Wxz7fZA7
+zPkP5t+zKf+seK/4ReMN8lXO/pV6hDn/kSfKzxWfyjMc509z9S/ke+Uv5KXG
+L+UV5v1f/Tear1J8q3iN4zxpJzfyXv1bxQ9yJx/lk3yWe9V/kQflX+Xs36lH
+OP6M5Ymcy1N5Js//7/8CjqUk5g==
+           "]]}, {
+          Hue[0.08640786499873876, 0.6, 0.6], 
+          Directive[
+           PointSize[0.002777777777777778], 
+           AbsoluteThickness[1.6], 
+           RGBColor[0.941176, 0.906538, 0.834043]], 
+          LineBox[CompressedData["
+1:eJxd2juQ81YVwHENNC5dULigEB6G2WEYxryXZ8R7Q3g4IQmbhId4BAwJiXiE
+mLcCBAwEonJLlS5VulTpUqVLdWyp0iXD+PyXuX83d35zzj3nXknWSv6+d3zv
+5Seef0uWZf95a5b9b7x8pkfSMSsuwyLGmcZ5jG+P8W3yQuPbNeaat1Tddyr/
+XYpfaT3vVvw96v9e9VvFyD7fFyP7f7/yP6D6H9T6PqT8D6v+RxS/1vo+qnof
+i3EZ48dj5Lh9Ikb2/0n5U+r/iPoV6XpqOft0Wq/GrO8zaf0as77Pqj5m/ufS
+/FrOPp/m15jj/wXFMev/ouKY/d+oP17G+Gjar35U8S+l/WpM/cdi5Pg8pviX
+Fces/yuqj5n/1RjZH2Z9X1Mc871ZxxjfiwJzPHD07zH9H0/rFzi+t/XjaX6P
++V4+EWN8rwvM8cZRv8fcF76errfAzFe8x9wnnkxdPJnm1zj69Zj9P5X2KzDn
+66k0v1c8e1rzn07za7yM+ZjvzzdijPNZYObj+P72mO/XbepCrjHrx3z/nknj
+xTNpvFa8x6z/2TS/wBy/Z9P8HnP8n4sxzk+BlzH/uTS/x+z/m2n94ptpfo25
+/jHzv5XGCxzfpxqzfsz6v526wHx/MNcvXsb4nTReYNYv95jjX8YYxz+XCxzX
+T4k5PziuvxbTT/mj4tl30/XkeBn9FS8x+1O8lXvlj5jz9z31lwu5xOwfR/1W
+8R7H8Rzl7PsxxvHNMf1x1C/xMvrj+PvRKr9X/qh49oN0PTmO9RQ4jlcp1zj2
+22KOv/JH9cueT9eTY+5nipeY44+jXqt4L4/Kz34YYxy/HLN/xUtMf+W3OJ4f
+exzf5xFz/f0oXU+OY36B6Y/pj+mv/F7xUc42ab18k8YLxUvM/R1z/Wt+j2M9
+o5z9WP0x9x/FS8zzEo7j1WKuf80fVT/7SbreXC4w/eVa+S3m+Cs+Yt4vXkjz
+c7l4Ic0vMc/jmOtf7uVR87MX1f/FNF48xC+fUvEac/xVr1d8VL3sp2k8x/RX
+vJRrzP1P8V4e5eyldH4uFy+l+aVcK7/FXP+Kj3L2Mr58csz3X/FS8VrxVu6V
+P2LOf5WuZ/7gWI+8kgt5LZdyhVm/4o3W0yreyb08yKM8ydnPUs/lXF7JhbyW
+S7mSa7mRW7mTe3mQR3mSs5+nnsu5vJILeS2XciXXciO3cif38iCP8iRnvwjH
+9TiXc3klFzg+a7l88GWsNL9WfiO3mt9h7i847u+D6o/Kn1Qv+2Xab47Zv7zC
+3J/ltfJLuZJr9W8Ubx/il7FTv17zB80fNX+Ss1fS/PkraTxXfCUXmP1rfilX
+ml8r3sit8jv165U/yKM8ydmv0vpzzPOY4ivM+Vd8LZfKr1S/VrzBy8vYYs6/
+6vc43jcG1RvlSfOzV9P681fT/FzxlVzg+P6tMc+LcoV5f1W8UbzVejrM+5XW
+Myh/VP4kZ9s0f445/5j9ywWOemvNL3Hsp1K/Wm4wz7MP/S6fTvV79R8w75ta
+76T1ZL9OPcfLy5jjWM9K+QWO+mvFSxzrqTD7lxvM+7TqdVpfr/xB+aPWP8nZ
+b9L1zeVcXmF+n8DRb41jfaXyK9Wrld9gzr/qd5rfa/4gj8qfMM+/v03jc8z1
+jzn/mPsfZv843vdLuVK9GsfxaVSv1Xo61euVP8ij+k2Y3/9/F2P8XjnH/B6D
+o/9KLnD8fr/Gy8tYYq5/xWv1a1S/VX6H498PetUflD+q3qR+2e/T+Bxz/1d8
+JReY8y+XcoX59xi5kVv16+Qes3/NH9V/0vzsDzEuL+Mc8/yHuf4x9z/M/R/H
+9VAqv5JrzW8Ub+UOs3/NH7SfEXP/V372x7T+HMf3K8fc/zD3P81fY/7+KV6p
+Xq14g7n/qV6Hef7T/EHzR8UnOavT9cxwzJ/j6LeQc+VfYZ4X5GvM9wfH8bzR
+etY4rsdbzS9x7GejepW81XprxXeq1yj/TvtvNX+v9XWqd1C81/yj+g2af1J8
+xMvLeK/8ST7r+GavpZ69lubPcax3ofwcc/5x7GeF43hdy4X63ajeWvm3Wk+p
++EbzKxzX31bxWt7JjebfaX+t1r+XO/mg9fbyUf0GvLyMJ/Uftd57zZ8UP2s9
+2Z/S/jPM30N5gXk+UPxKXsnX6lfIN5jnacVvMe+XOPa3Ub9K9baaXyu+kxv5
+TvVbea/87sGXz0Hr7bWeo/IH1TvJI47jc696k3zW/OzPqWfy/MGXzwLzfCBf
+ySv5WvUK+Ub5a/lWLuWNXMlbuVb/neKNfKfj02r+HvO+rvhB9XrVOyp/kE+a
+P8r38qT5Z8Wzv6SeyXMcn4WcK/9KXsnXml/IN/JavpVLeSNX8lau5Z3cyHdy
+K+/lTj7IvY7PUfFB8ZPio3wvT5p/Vjx7HV/G2etpfC4v5Fzzr+QV5u8/5vkP
+x/puNH+N4355q3ip+hu5Uv2t1l8rf6f6jfLv5Fb5e/XrVP+geK96R8UH+aT8
+Uf3vlT/JZ+Vnf009k+c45i8Uz3Hs70peaf615hfyjbzW/FvFS8zff+VXyt8q
+v9Z6d8pvlH+H+fuv/L36d4ofFO/V/6h+g3xS/1Hz7+VJ/c6ql/0tXd9MnuPl
+ZVxgfh/DnH8cz4cr+VrzC8z7n/qvFb9Vv1L1Npjnf3mr9dQ43md26t9o/p36
+tVrPXu5U76B4r3pHeVD/k47HqPr3yp+0v7Pi2S7G5WWcYZ7/FV9gvv+Y9z/M
++cex3mvVL1TvRl4r/xbHfkocv2du1L9S/63q1drfDsfvP43m36l/q/he9Tvl
+H5Tfq99R6x90fE84fl8bVf9e+ZN81n6zv6frneFYzxzHehaY938c+7lS/kq+
+xtG/UP8bzPu/fKv+pfpv5Er1tziurxrH8dypX6P8O8Vb7Wev/p36H3Bcr73q
+HeVB9U6qN8r3Oj6T4mfVz/4RI+//mN9/cKx3gTn/yr9SfIX5/mP+vz9eXsYb
+zV+r/i3m9x8c1+tGrrS/rerV8g5z/9f673D8+0Or9e+1vk71D9pfr/yj8gf1
+P2n+iPn9R/mT9n/GvP/9M+03k+c49rfA/P6r/CvM73+af614gWM/N/JavsWc
+f9XbKL+St1p/rfXv5Abz91/1WsX3Wl+n9R3Uv9f8o+oPyj9pfaPq36v/pPpn
+xbM3Yozvywzz76FvpPkLOcfc/zHvf6p3rfkF5v1P89eY+z/m+U/eqF4lb1Wv
+Vnyn/o3We6d+rfL3D758OvU74OVl7HX8jqo/qP5J8VG+13on+Sxn/0rXN5Pn
+OPovML//Yn7/xfz+g3n/V/1C8RvVWyt+q/WUqrdRvNJ6tqpXq99O8xvNv1O8
+lfdyp/oHxXut5ygP6n/S/FH7v1d8ks+qn/07rT/DPP9jzr/yc8Wv5BXm+U/x
+QvVu5DXm/Cteqt5GrjR/q3j94MtnJzfqdye38l7u1O8g9+p31PxB+Sflj/K9
+5k+KnxXP3kzrz95M4/OH+OWzkHP5Sl7J1//3fwF3Wweq
+           
+           "]]}}}, {}, {}, {{}, {}}, {{}, {}}}, {
+      DisplayFunction -> Identity, PlotRangePadding -> {{
+          Scaled[0.02], 
+          Scaled[0.02]}, {0, 
+          Scaled[0.05]}}, AxesOrigin -> {0., 0}, 
+       PlotRange -> {{0., 999.}, {0, 37.}}, PlotRangeClipping -> True, 
+       ImagePadding -> All, DisplayFunction -> Identity, AspectRatio -> 
+       NCache[GoldenRatio^(-1), 0.6180339887498948], Axes -> {True, True}, 
+       AxesLabel -> {None, None}, AxesOrigin -> {0., 0}, DisplayFunction :> 
+       Identity, Frame -> {{True, True}, {True, True}}, 
+       FrameLabel -> {{None, None}, {None, None}}, FrameStyle -> Directive[
+         GrayLevel[0.5], 
+         Thickness[Large]], 
+       FrameTicks -> {{Automatic, Automatic}, {Automatic, Automatic}}, 
+       GridLines -> {Automatic, Automatic}, GridLinesStyle -> Directive[
+         GrayLevel[0.5, 0.4]], ImageSize -> 750, 
+       Method -> {"CoordinatesToolOptions" -> {"DisplayFunction" -> ({
+             (Identity[#]& )[
+              Part[#, 1]], 
+             (Identity[#]& )[
+              Part[#, 2]]}& ), "CopiedValueFunction" -> ({
+             (Identity[#]& )[
+              Part[#, 1]], 
+             (Identity[#]& )[
+              Part[#, 2]]}& )}}, PlotRange -> {{0., 999.}, {0, 37.}}, 
+       PlotRangeClipping -> True, PlotRangePadding -> {{
+          Scaled[0.02], 
+          Scaled[0.02]}, {0, 
+          Scaled[0.05]}}, Ticks -> {Automatic, Automatic}}],FormBox[
+      FormBox[
+       TemplateBox[{
+        "\"F\"", "\"B\"", "\"R\"", "\"L\"", "\"O\"", "\"M\"", "\"S\""}, 
+        "LineLegend", DisplayFunction -> (FormBox[
+          StyleBox[
+           StyleBox[
+            PaneBox[
+             TagBox[
+              GridBox[{{
+                 TagBox[
+                  GridBox[{{
+                    GraphicsBox[{{
+                    Directive[
+                    EdgeForm[
+                    Directive[
+                    Opacity[0.3], 
+                    GrayLevel[0]]], 
+                    PointSize[0.05], 
+                    AbsoluteThickness[1.6], 
+                    RGBColor[0.293416, 0.0574044, 0.529412]], {
+                    LineBox[{{0, 10}, {20, 10}}]}}, {
+                    Directive[
+                    EdgeForm[
+                    Directive[
+                    Opacity[0.3], 
+                    GrayLevel[0]]], 
+                    PointSize[0.05], 
+                    AbsoluteThickness[1.6], 
+                    RGBColor[0.293416, 0.0574044, 0.529412]], {}}}, 
+                    AspectRatio -> Full, ImageSize -> {20, 10}, 
+                    PlotRangePadding -> None, ImagePadding -> Automatic, 
+                    BaselinePosition -> (Scaled[0.1] -> Baseline)], #}, {
+                    GraphicsBox[{{
+                    Directive[
+                    EdgeForm[
+                    Directive[
+                    Opacity[0.3], 
+                    GrayLevel[0]]], 
+                    PointSize[0.05], 
+                    AbsoluteThickness[1.6], 
+                    RGBColor[0.4286185, 0.2924847, 0.7194555]], {
+                    LineBox[{{0, 10}, {20, 10}}]}}, {
+                    Directive[
+                    EdgeForm[
+                    Directive[
+                    Opacity[0.3], 
+                    GrayLevel[0]]], 
+                    PointSize[0.05], 
+                    AbsoluteThickness[1.6], 
+                    RGBColor[0.4286185, 0.2924847, 0.7194555]], {}}}, 
+                    AspectRatio -> Full, ImageSize -> {20, 10}, 
+                    PlotRangePadding -> None, ImagePadding -> Automatic, 
+                    BaselinePosition -> (Scaled[0.1] -> Baseline)], #2}, {
+                    GraphicsBox[{{
+                    Directive[
+                    EdgeForm[
+                    Directive[
+                    Opacity[0.3], 
+                    GrayLevel[0]]], 
+                    PointSize[0.05], 
+                    AbsoluteThickness[1.6], 
+                    RGBColor[0.563821, 0.527565, 0.909499]], {
+                    LineBox[{{0, 10}, {20, 10}}]}}, {
+                    Directive[
+                    EdgeForm[
+                    Directive[
+                    Opacity[0.3], 
+                    GrayLevel[0]]], 
+                    PointSize[0.05], 
+                    AbsoluteThickness[1.6], 
+                    RGBColor[0.563821, 0.527565, 0.909499]], {}}}, 
+                    AspectRatio -> Full, ImageSize -> {20, 10}, 
+                    PlotRangePadding -> None, ImagePadding -> Automatic, 
+                    BaselinePosition -> (Scaled[0.1] -> Baseline)], #3}, {
+                    GraphicsBox[{{
+                    Directive[
+                    EdgeForm[
+                    Directive[
+                    Opacity[0.3], 
+                    GrayLevel[0]]], 
+                    PointSize[0.05], 
+                    AbsoluteThickness[1.6], 
+                    RGBColor[0.663226, 0.6872815, 0.9117649999999999]], {
+                    LineBox[{{0, 10}, {20, 10}}]}}, {
+                    Directive[
+                    EdgeForm[
+                    Directive[
+                    Opacity[0.3], 
+                    GrayLevel[0]]], 
+                    PointSize[0.05], 
+                    AbsoluteThickness[1.6], 
+                    RGBColor[0.663226, 0.6872815, 0.9117649999999999]], {}}}, 
+                    AspectRatio -> Full, ImageSize -> {20, 10}, 
+                    PlotRangePadding -> None, ImagePadding -> Automatic, 
+                    BaselinePosition -> (Scaled[0.1] -> Baseline)], #4}, {
+                    GraphicsBox[{{
+                    Directive[
+                    EdgeForm[
+                    Directive[
+                    Opacity[0.3], 
+                    GrayLevel[0]]], 
+                    PointSize[0.05], 
+                    AbsoluteThickness[1.6], 
+                    RGBColor[0.762631, 0.846998, 0.914031]], {
+                    LineBox[{{0, 10}, {20, 10}}]}}, {
+                    Directive[
+                    EdgeForm[
+                    Directive[
+                    Opacity[0.3], 
+                    GrayLevel[0]]], 
+                    PointSize[0.05], 
+                    AbsoluteThickness[1.6], 
+                    RGBColor[0.762631, 0.846998, 0.914031]], {}}}, 
+                    AspectRatio -> Full, ImageSize -> {20, 10}, 
+                    PlotRangePadding -> None, ImagePadding -> Automatic, 
+                    BaselinePosition -> (Scaled[0.1] -> Baseline)], #5}, {
+                    GraphicsBox[{{
+                    Directive[
+                    EdgeForm[
+                    Directive[
+                    Opacity[0.3], 
+                    GrayLevel[0]]], 
+                    PointSize[0.05], 
+                    AbsoluteThickness[1.6], 
+                    RGBColor[0.8519034999999999, 0.876768, 0.874037]], {
+                    LineBox[{{0, 10}, {20, 10}}]}}, {
+                    Directive[
+                    EdgeForm[
+                    Directive[
+                    Opacity[0.3], 
+                    GrayLevel[0]]], 
+                    PointSize[0.05], 
+                    AbsoluteThickness[1.6], 
+                    RGBColor[0.8519034999999999, 0.876768, 0.874037]], {}}}, 
+                    AspectRatio -> Full, ImageSize -> {20, 10}, 
+                    PlotRangePadding -> None, ImagePadding -> Automatic, 
+                    BaselinePosition -> (Scaled[0.1] -> Baseline)], #6}, {
+                    GraphicsBox[{{
+                    Directive[
+                    EdgeForm[
+                    Directive[
+                    Opacity[0.3], 
+                    GrayLevel[0]]], 
+                    PointSize[0.05], 
+                    AbsoluteThickness[1.6], 
+                    RGBColor[0.941176, 0.906538, 0.834043]], {
+                    LineBox[{{0, 10}, {20, 10}}]}}, {
+                    Directive[
+                    EdgeForm[
+                    Directive[
+                    Opacity[0.3], 
+                    GrayLevel[0]]], 
+                    PointSize[0.05], 
+                    AbsoluteThickness[1.6], 
+                    RGBColor[0.941176, 0.906538, 0.834043]], {}}}, 
+                    AspectRatio -> Full, ImageSize -> {20, 10}, 
+                    PlotRangePadding -> None, ImagePadding -> Automatic, 
+                    BaselinePosition -> (Scaled[0.1] -> Baseline)], #7}}, 
+                   GridBoxAlignment -> {
+                    "Columns" -> {Center, Left}, "Rows" -> {{Baseline}}}, 
+                   AutoDelete -> False, 
+                   GridBoxDividers -> {
+                    "Columns" -> {{False}}, "Rows" -> {{False}}}, 
+                   GridBoxItemSize -> {
+                    "Columns" -> {{All}}, "Rows" -> {{All}}}, 
+                   GridBoxSpacings -> {
+                    "Columns" -> {{0.5}}, "Rows" -> {{0.8}}}], "Grid"]}}, 
+               GridBoxAlignment -> {"Columns" -> {{Left}}, "Rows" -> {{Top}}},
+                AutoDelete -> False, 
+               GridBoxItemSize -> {
+                "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+               GridBoxSpacings -> {"Columns" -> {{1}}, "Rows" -> {{0}}}], 
+              "Grid"], Alignment -> Left, AppearanceElements -> None, 
+             ImageMargins -> {{5, 5}, {5, 5}}, ImageSizeAction -> 
+             "ResizeToFit"], LineIndent -> 0, StripOnInput -> False], {
+           FontFamily -> "Arial"}, Background -> Automatic, StripOnInput -> 
+           False], TraditionalForm]& ), 
+        InterpretationFunction :> (RowBox[{"LineLegend", "[", 
+           RowBox[{
+             RowBox[{"{", 
+               RowBox[{
+                 RowBox[{"Directive", "[", 
+                   RowBox[{
+                    RowBox[{"PointSize", "[", "0.002777777777777778`", "]"}], 
+                    ",", 
+                    RowBox[{"AbsoluteThickness", "[", "1.6`", "]"}], ",", 
+                    InterpretationBox[
+                    ButtonBox[
+                    TooltipBox[
+                    GraphicsBox[{{
+                    GrayLevel[0], 
+                    RectangleBox[{0, 0}]}, {
+                    GrayLevel[0], 
+                    RectangleBox[{1, -1}]}, {
+                    RGBColor[0.293416, 0.0574044, 0.529412], 
+                    RectangleBox[{0, -1}, {2, 1}]}}, AspectRatio -> 1, Frame -> 
+                    True, FrameStyle -> 
+                    RGBColor[
+                    0.19561066666666668`, 0.0382696, 0.35294133333333333`], 
+                    FrameTicks -> None, PlotRangePadding -> None, ImageSize -> 
+                    Dynamic[{
+                    Automatic, 1.35 CurrentValue["FontCapHeight"]/
+                    AbsoluteCurrentValue[Magnification]}]], 
+                    "RGBColor[0.293416, 0.0574044, 0.529412]"], Appearance -> 
+                    None, BaseStyle -> {}, BaselinePosition -> Baseline, 
+                    DefaultBaseStyle -> {}, ButtonFunction :> 
+                    With[{Typeset`box$ = EvaluationBox[]}, 
+                    If[
+                    Not[
+                    AbsoluteCurrentValue["Deployed"]], 
+                    SelectionMove[Typeset`box$, All, Expression]; 
+                    FrontEnd`Private`$ColorSelectorInitialAlpha = 1; 
+                    FrontEnd`Private`$ColorSelectorInitialColor = 
+                    RGBColor[0.293416, 0.0574044, 0.529412]; 
+                    FrontEnd`Private`$ColorSelectorUseMakeBoxes = True; 
+                    MathLink`CallFrontEnd[
+                    FrontEnd`AttachCell[Typeset`box$, 
+                    FrontEndResource["RGBColorValueSelector"], {
+                    0, {Left, Bottom}}, {Left, Top}, 
+                    "ClosingActions" -> {
+                    "SelectionDeparture", "ParentChanged", 
+                    "EvaluatorQuit"}]]]], BaseStyle -> Inherited, Evaluator -> 
+                    Automatic, Method -> "Preemptive"], 
+                    RGBColor[0.293416, 0.0574044, 0.529412], Editable -> 
+                    False, Selectable -> False]}], "]"}], ",", 
+                 RowBox[{"Directive", "[", 
+                   RowBox[{
+                    RowBox[{"PointSize", "[", "0.002777777777777778`", "]"}], 
+                    ",", 
+                    RowBox[{"AbsoluteThickness", "[", "1.6`", "]"}], ",", 
+                    InterpretationBox[
+                    ButtonBox[
+                    TooltipBox[
+                    GraphicsBox[{{
+                    GrayLevel[0], 
+                    RectangleBox[{0, 0}]}, {
+                    GrayLevel[0], 
+                    RectangleBox[{1, -1}]}, {
+                    RGBColor[0.4286185, 0.2924847, 0.7194555], 
+                    RectangleBox[{0, -1}, {2, 1}]}}, AspectRatio -> 1, Frame -> 
+                    True, FrameStyle -> 
+                    RGBColor[
+                    0.2857456666666667, 0.1949898, 0.47963700000000004`], 
+                    FrameTicks -> None, PlotRangePadding -> None, ImageSize -> 
+                    Dynamic[{
+                    Automatic, 1.35 CurrentValue["FontCapHeight"]/
+                    AbsoluteCurrentValue[Magnification]}]], 
+                    "RGBColor[0.4286185, 0.2924847, 0.7194555]"], Appearance -> 
+                    None, BaseStyle -> {}, BaselinePosition -> Baseline, 
+                    DefaultBaseStyle -> {}, ButtonFunction :> 
+                    With[{Typeset`box$ = EvaluationBox[]}, 
+                    If[
+                    Not[
+                    AbsoluteCurrentValue["Deployed"]], 
+                    SelectionMove[Typeset`box$, All, Expression]; 
+                    FrontEnd`Private`$ColorSelectorInitialAlpha = 1; 
+                    FrontEnd`Private`$ColorSelectorInitialColor = 
+                    RGBColor[0.4286185, 0.2924847, 0.7194555]; 
+                    FrontEnd`Private`$ColorSelectorUseMakeBoxes = True; 
+                    MathLink`CallFrontEnd[
+                    FrontEnd`AttachCell[Typeset`box$, 
+                    FrontEndResource["RGBColorValueSelector"], {
+                    0, {Left, Bottom}}, {Left, Top}, 
+                    "ClosingActions" -> {
+                    "SelectionDeparture", "ParentChanged", 
+                    "EvaluatorQuit"}]]]], BaseStyle -> Inherited, Evaluator -> 
+                    Automatic, Method -> "Preemptive"], 
+                    RGBColor[0.4286185, 0.2924847, 0.7194555], Editable -> 
+                    False, Selectable -> False]}], "]"}], ",", 
+                 RowBox[{"Directive", "[", 
+                   RowBox[{
+                    RowBox[{"PointSize", "[", "0.002777777777777778`", "]"}], 
+                    ",", 
+                    RowBox[{"AbsoluteThickness", "[", "1.6`", "]"}], ",", 
+                    InterpretationBox[
+                    ButtonBox[
+                    TooltipBox[
+                    GraphicsBox[{{
+                    GrayLevel[0], 
+                    RectangleBox[{0, 0}]}, {
+                    GrayLevel[0], 
+                    RectangleBox[{1, -1}]}, {
+                    RGBColor[0.563821, 0.527565, 0.909499], 
+                    RectangleBox[{0, -1}, {2, 1}]}}, AspectRatio -> 1, Frame -> 
+                    True, FrameStyle -> 
+                    RGBColor[
+                    0.3758806666666667, 0.35170999999999997`, 
+                    0.6063326666666666], FrameTicks -> None, PlotRangePadding -> 
+                    None, ImageSize -> 
+                    Dynamic[{
+                    Automatic, 1.35 CurrentValue["FontCapHeight"]/
+                    AbsoluteCurrentValue[Magnification]}]], 
+                    "RGBColor[0.563821, 0.527565, 0.909499]"], Appearance -> 
+                    None, BaseStyle -> {}, BaselinePosition -> Baseline, 
+                    DefaultBaseStyle -> {}, ButtonFunction :> 
+                    With[{Typeset`box$ = EvaluationBox[]}, 
+                    If[
+                    Not[
+                    AbsoluteCurrentValue["Deployed"]], 
+                    SelectionMove[Typeset`box$, All, Expression]; 
+                    FrontEnd`Private`$ColorSelectorInitialAlpha = 1; 
+                    FrontEnd`Private`$ColorSelectorInitialColor = 
+                    RGBColor[0.563821, 0.527565, 0.909499]; 
+                    FrontEnd`Private`$ColorSelectorUseMakeBoxes = True; 
+                    MathLink`CallFrontEnd[
+                    FrontEnd`AttachCell[Typeset`box$, 
+                    FrontEndResource["RGBColorValueSelector"], {
+                    0, {Left, Bottom}}, {Left, Top}, 
+                    "ClosingActions" -> {
+                    "SelectionDeparture", "ParentChanged", 
+                    "EvaluatorQuit"}]]]], BaseStyle -> Inherited, Evaluator -> 
+                    Automatic, Method -> "Preemptive"], 
+                    RGBColor[0.563821, 0.527565, 0.909499], Editable -> False,
+                     Selectable -> False]}], "]"}], ",", 
+                 RowBox[{"Directive", "[", 
+                   RowBox[{
+                    RowBox[{"PointSize", "[", "0.002777777777777778`", "]"}], 
+                    ",", 
+                    RowBox[{"AbsoluteThickness", "[", "1.6`", "]"}], ",", 
+                    InterpretationBox[
+                    ButtonBox[
+                    TooltipBox[
+                    GraphicsBox[{{
+                    GrayLevel[0], 
+                    RectangleBox[{0, 0}]}, {
+                    GrayLevel[0], 
+                    RectangleBox[{1, -1}]}, {
+                    RGBColor[0.663226, 0.6872815, 0.9117649999999999], 
+                    RectangleBox[{0, -1}, {2, 1}]}}, AspectRatio -> 1, Frame -> 
+                    True, FrameStyle -> 
+                    RGBColor[
+                    0.4421506666666667, 0.45818766666666666`, 
+                    0.6078433333333333], FrameTicks -> None, PlotRangePadding -> 
+                    None, ImageSize -> 
+                    Dynamic[{
+                    Automatic, 1.35 CurrentValue["FontCapHeight"]/
+                    AbsoluteCurrentValue[Magnification]}]], 
+                    "RGBColor[0.663226, 0.6872815, 0.9117649999999999]"], 
+                    Appearance -> None, BaseStyle -> {}, BaselinePosition -> 
+                    Baseline, DefaultBaseStyle -> {}, ButtonFunction :> 
+                    With[{Typeset`box$ = EvaluationBox[]}, 
+                    If[
+                    Not[
+                    AbsoluteCurrentValue["Deployed"]], 
+                    SelectionMove[Typeset`box$, All, Expression]; 
+                    FrontEnd`Private`$ColorSelectorInitialAlpha = 1; 
+                    FrontEnd`Private`$ColorSelectorInitialColor = 
+                    RGBColor[0.663226, 0.6872815, 0.9117649999999999]; 
+                    FrontEnd`Private`$ColorSelectorUseMakeBoxes = True; 
+                    MathLink`CallFrontEnd[
+                    FrontEnd`AttachCell[Typeset`box$, 
+                    FrontEndResource["RGBColorValueSelector"], {
+                    0, {Left, Bottom}}, {Left, Top}, 
+                    "ClosingActions" -> {
+                    "SelectionDeparture", "ParentChanged", 
+                    "EvaluatorQuit"}]]]], BaseStyle -> Inherited, Evaluator -> 
+                    Automatic, Method -> "Preemptive"], 
+                    RGBColor[0.663226, 0.6872815, 0.9117649999999999], 
+                    Editable -> False, Selectable -> False]}], "]"}], ",", 
+                 RowBox[{"Directive", "[", 
+                   RowBox[{
+                    RowBox[{"PointSize", "[", "0.002777777777777778`", "]"}], 
+                    ",", 
+                    RowBox[{"AbsoluteThickness", "[", "1.6`", "]"}], ",", 
+                    InterpretationBox[
+                    ButtonBox[
+                    TooltipBox[
+                    GraphicsBox[{{
+                    GrayLevel[0], 
+                    RectangleBox[{0, 0}]}, {
+                    GrayLevel[0], 
+                    RectangleBox[{1, -1}]}, {
+                    RGBColor[0.762631, 0.846998, 0.914031], 
+                    RectangleBox[{0, -1}, {2, 1}]}}, AspectRatio -> 1, Frame -> 
+                    True, FrameStyle -> 
+                    RGBColor[
+                    0.5084206666666666, 0.5646653333333334, 
+                    0.6093540000000001], FrameTicks -> None, PlotRangePadding -> 
+                    None, ImageSize -> 
+                    Dynamic[{
+                    Automatic, 1.35 CurrentValue["FontCapHeight"]/
+                    AbsoluteCurrentValue[Magnification]}]], 
+                    "RGBColor[0.762631, 0.846998, 0.914031]"], Appearance -> 
+                    None, BaseStyle -> {}, BaselinePosition -> Baseline, 
+                    DefaultBaseStyle -> {}, ButtonFunction :> 
+                    With[{Typeset`box$ = EvaluationBox[]}, 
+                    If[
+                    Not[
+                    AbsoluteCurrentValue["Deployed"]], 
+                    SelectionMove[Typeset`box$, All, Expression]; 
+                    FrontEnd`Private`$ColorSelectorInitialAlpha = 1; 
+                    FrontEnd`Private`$ColorSelectorInitialColor = 
+                    RGBColor[0.762631, 0.846998, 0.914031]; 
+                    FrontEnd`Private`$ColorSelectorUseMakeBoxes = True; 
+                    MathLink`CallFrontEnd[
+                    FrontEnd`AttachCell[Typeset`box$, 
+                    FrontEndResource["RGBColorValueSelector"], {
+                    0, {Left, Bottom}}, {Left, Top}, 
+                    "ClosingActions" -> {
+                    "SelectionDeparture", "ParentChanged", 
+                    "EvaluatorQuit"}]]]], BaseStyle -> Inherited, Evaluator -> 
+                    Automatic, Method -> "Preemptive"], 
+                    RGBColor[0.762631, 0.846998, 0.914031], Editable -> False,
+                     Selectable -> False]}], "]"}], ",", 
+                 RowBox[{"Directive", "[", 
+                   RowBox[{
+                    RowBox[{"PointSize", "[", "0.002777777777777778`", "]"}], 
+                    ",", 
+                    RowBox[{"AbsoluteThickness", "[", "1.6`", "]"}], ",", 
+                    InterpretationBox[
+                    ButtonBox[
+                    TooltipBox[
+                    GraphicsBox[{{
+                    GrayLevel[0], 
+                    RectangleBox[{0, 0}]}, {
+                    GrayLevel[0], 
+                    RectangleBox[{1, -1}]}, {
+                    RGBColor[0.8519034999999999, 0.876768, 0.874037], 
+                    RectangleBox[{0, -1}, {2, 1}]}}, AspectRatio -> 1, Frame -> 
+                    True, FrameStyle -> 
+                    RGBColor[
+                    0.5679356666666666, 0.584512, 0.5826913333333333], 
+                    FrameTicks -> None, PlotRangePadding -> None, ImageSize -> 
+                    Dynamic[{
+                    Automatic, 1.35 CurrentValue["FontCapHeight"]/
+                    AbsoluteCurrentValue[Magnification]}]], 
+                    "RGBColor[0.8519034999999999, 0.876768, 0.874037]"], 
+                    Appearance -> None, BaseStyle -> {}, BaselinePosition -> 
+                    Baseline, DefaultBaseStyle -> {}, ButtonFunction :> 
+                    With[{Typeset`box$ = EvaluationBox[]}, 
+                    If[
+                    Not[
+                    AbsoluteCurrentValue["Deployed"]], 
+                    SelectionMove[Typeset`box$, All, Expression]; 
+                    FrontEnd`Private`$ColorSelectorInitialAlpha = 1; 
+                    FrontEnd`Private`$ColorSelectorInitialColor = 
+                    RGBColor[0.8519034999999999, 0.876768, 0.874037]; 
+                    FrontEnd`Private`$ColorSelectorUseMakeBoxes = True; 
+                    MathLink`CallFrontEnd[
+                    FrontEnd`AttachCell[Typeset`box$, 
+                    FrontEndResource["RGBColorValueSelector"], {
+                    0, {Left, Bottom}}, {Left, Top}, 
+                    "ClosingActions" -> {
+                    "SelectionDeparture", "ParentChanged", 
+                    "EvaluatorQuit"}]]]], BaseStyle -> Inherited, Evaluator -> 
+                    Automatic, Method -> "Preemptive"], 
+                    RGBColor[0.8519034999999999, 0.876768, 0.874037], 
+                    Editable -> False, Selectable -> False]}], "]"}], ",", 
+                 RowBox[{"Directive", "[", 
+                   RowBox[{
+                    RowBox[{"PointSize", "[", "0.002777777777777778`", "]"}], 
+                    ",", 
+                    RowBox[{"AbsoluteThickness", "[", "1.6`", "]"}], ",", 
+                    InterpretationBox[
+                    ButtonBox[
+                    TooltipBox[
+                    GraphicsBox[{{
+                    GrayLevel[0], 
+                    RectangleBox[{0, 0}]}, {
+                    GrayLevel[0], 
+                    RectangleBox[{1, -1}]}, {
+                    RGBColor[0.941176, 0.906538, 0.834043], 
+                    RectangleBox[{0, -1}, {2, 1}]}}, AspectRatio -> 1, Frame -> 
+                    True, FrameStyle -> 
+                    RGBColor[
+                    0.6274506666666667, 0.6043586666666667, 
+                    0.5560286666666667], FrameTicks -> None, PlotRangePadding -> 
+                    None, ImageSize -> 
+                    Dynamic[{
+                    Automatic, 1.35 CurrentValue["FontCapHeight"]/
+                    AbsoluteCurrentValue[Magnification]}]], 
+                    "RGBColor[0.941176, 0.906538, 0.834043]"], Appearance -> 
+                    None, BaseStyle -> {}, BaselinePosition -> Baseline, 
+                    DefaultBaseStyle -> {}, ButtonFunction :> 
+                    With[{Typeset`box$ = EvaluationBox[]}, 
+                    If[
+                    Not[
+                    AbsoluteCurrentValue["Deployed"]], 
+                    SelectionMove[Typeset`box$, All, Expression]; 
+                    FrontEnd`Private`$ColorSelectorInitialAlpha = 1; 
+                    FrontEnd`Private`$ColorSelectorInitialColor = 
+                    RGBColor[0.941176, 0.906538, 0.834043]; 
+                    FrontEnd`Private`$ColorSelectorUseMakeBoxes = True; 
+                    MathLink`CallFrontEnd[
+                    FrontEnd`AttachCell[Typeset`box$, 
+                    FrontEndResource["RGBColorValueSelector"], {
+                    0, {Left, Bottom}}, {Left, Top}, 
+                    "ClosingActions" -> {
+                    "SelectionDeparture", "ParentChanged", 
+                    "EvaluatorQuit"}]]]], BaseStyle -> Inherited, Evaluator -> 
+                    Automatic, Method -> "Preemptive"], 
+                    RGBColor[0.941176, 0.906538, 0.834043], Editable -> False,
+                     Selectable -> False]}], "]"}]}], "}"}], ",", 
+             RowBox[{"{", 
+               RowBox[{#, ",", #2, ",", #3, ",", #4, ",", #5, ",", #6, 
+                 ",", #7}], "}"}], ",", 
+             RowBox[{"LegendMarkers", "\[Rule]", 
+               RowBox[{"{", 
+                 RowBox[{
+                   RowBox[{"{", 
+                    RowBox[{"False", ",", "Automatic"}], "}"}], ",", 
+                   RowBox[{"{", 
+                    RowBox[{"False", ",", "Automatic"}], "}"}], ",", 
+                   RowBox[{"{", 
+                    RowBox[{"False", ",", "Automatic"}], "}"}], ",", 
+                   RowBox[{"{", 
+                    RowBox[{"False", ",", "Automatic"}], "}"}], ",", 
+                   RowBox[{"{", 
+                    RowBox[{"False", ",", "Automatic"}], "}"}], ",", 
+                   RowBox[{"{", 
+                    RowBox[{"False", ",", "Automatic"}], "}"}], ",", 
+                   RowBox[{"{", 
+                    RowBox[{"False", ",", "Automatic"}], "}"}]}], "}"}]}], 
+             ",", 
+             RowBox[{"Joined", "\[Rule]", 
+               RowBox[{"{", 
+                 
+                 RowBox[{
+                  "True", ",", "True", ",", "True", ",", "True", ",", "True", 
+                   ",", "True", ",", "True"}], "}"}]}], ",", 
+             RowBox[{"LabelStyle", "\[Rule]", 
+               RowBox[{"{", "}"}]}], ",", 
+             RowBox[{"LegendLayout", "\[Rule]", "\"Column\""}]}], "]"}]& ), 
+        Editable -> True], TraditionalForm], TraditionalForm]},
+    "Legended",
+    DisplayFunction->(GridBox[{{
+        TagBox[
+         ItemBox[
+          PaneBox[
+           TagBox[#, "SkipImageSizeLevel"], Alignment -> {Center, Baseline}, 
+           BaselinePosition -> Baseline], DefaultBaseStyle -> "Labeled"], 
+         "SkipImageSizeLevel"], 
+        ItemBox[#2, DefaultBaseStyle -> "LabeledLabel"]}}, 
+      GridBoxAlignment -> {"Columns" -> {{Center}}, "Rows" -> {{Center}}}, 
+      AutoDelete -> False, GridBoxItemSize -> Automatic, 
+      BaselinePosition -> {1, 1}]& ),
+    Editable->True,
+    InterpretationFunction->(RowBox[{"Legended", "[", 
+       RowBox[{#, ",", 
+         RowBox[{"Placed", "[", 
+           RowBox[{#2, ",", "After"}], "]"}]}], "]"}]& )]}], "}"}]], "Output",\
+
+ CellChangeTimes->{{3.721573196500379*^9, 3.721573238537655*^9}, {
+  3.721573331916349*^9, 3.7215733510775337`*^9}, {3.721573397411191*^9, 
+  3.7215734370257196`*^9}, {3.721573484508605*^9, 3.721573505445148*^9}, {
+  3.7215736419941893`*^9, 3.721573658306859*^9}, {3.721573731513576*^9, 
+  3.721573738369928*^9}, {3.7215738661302013`*^9, 3.721573872259843*^9}, {
+  3.721573902539761*^9, 
+  3.721573928333933*^9}},ExpressionUUID->"d67dfbb2-f39a-4172-85bf-\
+19f08e645771"]
+}, Open  ]]
+},
+WindowSize->{2178, 1260},
+WindowMargins->{{0, Automatic}, {Automatic, 0}},
+FrontEndVersion->"11.1 for Mac OS X x86 (32-bit, 64-bit Kernel) (April 27, \
+2017)",
+StyleDefinitions->"Default.nb"
+]
+(* End of Notebook Content *)
+
+(* Internal cache information *)
+(*CellTagsOutline
+CellTagsIndex->{}
+*)
+(*CellTagsIndex
+CellTagsIndex->{}
+*)
+(*NotebookFileOutline
+Notebook[{
+Cell[CellGroupData[{
+Cell[580, 22, 4081, 105, 348, "Input", "ExpressionUUID" -> \
+"6e6e83fe-a091-422f-89b0-b762b3bb1c02"],
+Cell[4664, 129, 82653, 1546, 489, "Output", "ExpressionUUID" -> \
+"d67dfbb2-f39a-4172-85bf-19f08e645771"]
+}, Open  ]]
+}
+]
+*)
+


### PR DESCRIPTION
## Proposed changes

SwarmSpray and ATSB's now work on both male and female mosquitoes. These interventions were working only on females because their implementations are separated in the files: _MBITES-Male-Bouts.R_ and _MBITES-Complex-Bouts.R_.

Ovitraps do not have this problem because... well... males don't oviposit. IRS is still unimplemented so it does not have this problem... yet.

I'm closing raised issue (https://github.com/smitdave/MASH-Main/issues/44), as this has been resolved.

## Types of changes

What types of changes does your code introduce to MASH?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
