### PR TITLE
Changed P->S event handling to write P2S instead of S

### DIFF
--- a/MASH-MACRO/R/PATHOGEN-PfSI-Methods.R
+++ b/MASH-MACRO/R/PATHOGEN-PfSI-Methods.R
@@ -499,7 +499,7 @@ event_endprophylaxisPfSI <- function(tEvent, PAR = NULL){
 #' @param PAR \code{NULL}
 endprophylaxisPfSI <- function(tEvent, PAR){
   # End Prophylaxis
-  writeLines(text = paste0(c(private$myID,tEvent,"S","NULL"),collapse = ","),con = private$HumansPointer$get_conPathogen(), sep = "\n")
+  writeLines(text = paste0(c(private$myID,tEvent,"P2S","NULL"),collapse = ","),con = private$HumansPointer$get_conPathogen(), sep = "\n")
   private$Pathogens$set_chemoprophylaxis(FALSE)
 
 }


### PR DESCRIPTION
## Proposed changes

Previously, the event logger was writing out "S" events when Prophylaxis was wearing off (and a human was returning from Protected to Susceptible).  This doesn't work, because "S" events are also logged when a Human goes from being Infected to being Susceptible.  I have changed the encoding to "P2S" to keep it distinct from "S"

## Types of changes

What types of changes does your code introduce to MASH?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] No changes (just sync or minor updates to non-essential code)