### PR TITLE
initialize_output_Mosquito_RM now saves the initial conditions

### DIFF
--- a/MASH-MACRO/R/MACRO-Tile-Simulation.R
+++ b/MASH-MACRO/R/MACRO-Tile-Simulation.R
@@ -22,7 +22,7 @@
 #'
 #'  * This method is bound to \code{MacroTile$simMacro}
 #'
-simMacro <- function(tMax, PfPAR, message = TRUE){
+simMacro <- function(tMax, PfPAR){
 
   cat("initializing simulation, ",private$runID,"\n",sep="")
 

--- a/MASH-MACRO/R/MOSQUITO-MosquitoRM-Simulation.R
+++ b/MASH-MACRO/R/MOSQUITO-MosquitoRM-Simulation.R
@@ -103,6 +103,10 @@ Mosquito_RM$set(which = "public",name = "get_emergingAdults",
 #'
 initialize_output_Mosquito_RM <- function(con){
   writeLines(text = paste0(c("time","state",paste0("patch",1:private$TilePointer$get_nPatch())),collapse = ","),con = con, sep = "\n")
+  tNow = private$TilePointer$get_tNow()
+  writeLines(text = paste0(c(tNow,"M",private$M),collapse = ","), con = con, sep = "\n")
+  writeLines(text = paste0(c(tNow,"Y",private$Y),collapse = ","), con = con, sep = "\n")
+  writeLines(text = paste0(c(tNow,"Z",private$Z),collapse = ","), con = con, sep = "\n")
 }
 
 Mosquito_RM$set(which = "public",name = "initialize_output",


### PR DESCRIPTION
## Proposed changes

Previously, the initial conditions for the Mosquito populations were not being recorded in Mosquito_RunX.csv, meaning there was a data point missing from the time series.

Changed the initialize_output_Mosquito_RM function in MOSQUITO-MosquitoRM-Simulation so that it would output the initial conditions for Mosquito populations.

## Types of changes

What types of changes does your code introduce to MASH?
_Put an `x` in the boxes that apply_

- [ x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] No changes (just sync or minor updates to non-essential code)