### PR TITLE
may have solved dependency between PPRFlight and how to reset bmSize

### DIFF
--- a/MASH-dev/SeanWu/MBITES/R/MBITES-Oogenesis.R
+++ b/MASH-dev/SeanWu/MBITES/R/MBITES-Oogenesis.R
@@ -48,6 +48,16 @@ mbites_oogenesis1 <- function(){
   private$eggT = self$rEggMaturationTime()
   #NOTE: the post prandial resting period is in MBITES-Timing.R
   #NOTE: self$checkRefeed() is called in MBITES-Bouts.R :: updateState()
+  # private$bmSize = 0 # check with DS IN mbites_checkPostPrandial
+}
+
+#' MBITES: Oogenesis Model 1 Blood Meal Size Reset
+#'
+#' In the first model of oogenesis blood meal size is reset to 0 during the
+#' post-prandial rest (\code{\link{mbites_checkPostPrandial}}).
+#'  * This method is bound to \code{Mosquito_Female$PPRbmSize}
+mbites_PPRbmSize1 <- function(){
+  private$bmSize = 0
 }
 
 #' MBITES: Normally-distributed Egg Maturation Time
@@ -81,9 +91,20 @@ mbites_oogenesis2 <- function(){
   }
   # egg provision: after we've fed enough then mosquito is gravid
   private$eggP = private$eggP - private$bmSize
+  # private$bmSize = max(0,private$bmSize - private$eggP) # check with DS IN mbites_checkPostPrandial
   if(private$eggP < 0){
     private$gravid = TRUE
   }
+}
+
+#' MBITES: Oogenesis Model 2 Blood Meal Size Reset
+#'
+#' In the second model of oogenesis blood meal size is reduced by an amount equal to
+#' the amount of blood used in the egg provision, or to 0 if that would induce a negative amount.
+#' This occurs during the post-prandial rest (\code{\link{mbites_checkPostPrandial}}).
+#'  * This method is bound to \code{Mosquito_Female$PPRbmSize}
+mbites_PPRbmSize2 <- function(){
+  private$bmSize = max(0,private$bmSize - private$eggP)
 }
 
 #' MBITES: Draw Normally-distributed Egg Batch Size

--- a/MASH-dev/SeanWu/MBITES/R/MBITES-Survival.R
+++ b/MASH-dev/SeanWu/MBITES/R/MBITES-Survival.R
@@ -13,8 +13,8 @@
 
 #' MBITES: Survival
 #'
-#' write about me!
-#'
+#' Survival from flight and local hazards is calculated after the mosquito chooses
+#' a resting spot, after the "attempt" part of the bout (called in \code{\link{mbites_updateState}}).
 #'
 #'
 #' @name Survival

--- a/MASH-dev/SeanWu/MBITES/R/MBITES-Timing.R
+++ b/MASH-dev/SeanWu/MBITES/R/MBITES-Timing.R
@@ -75,6 +75,7 @@ mbites_checkPostPrandial <- function(){
     ppRest = MBITES:::Parameters$ttEvent_ppRest()
     private$tNext = private$tNow = private$tNow + ppRest
     private$bloodfed = FALSE
+    self$PPRbmSize() # check with DS
   }
 }
 


### PR DESCRIPTION
during oogenesis, bmSize is _not_ reset, because oogenesis is called during the BloodMeal, resetting bmSize = 0 would cause a problem because in UpdateState -> survival called after, PPRFlight needs to know the bmSize to calculate mortality due to blood meal size. Instead we rely on the bloodfed = TRUE flag being on in timing when we call `mbites_checkPostPrandial` to reset bmSize with the function appropriate for the oogenesis model we used.