### PR TITLE
change to vaccination function

### DIFF
--- a/MASH-dev/SeanWu/MACRO-dev/MACRO/R/Human-PfSI.R
+++ b/MASH-dev/SeanWu/MACRO-dev/MACRO/R/Human-PfSI.R
@@ -109,9 +109,9 @@ check_human_pfsi_conpars <- function(par){
 #' @param type "PE" (sporozoite-blocking) or "GS" (gametocyte-killing)
 #'
 #' @export
-pevaxx_pfsi_conpars <- function(id,t,treat,type){
+vaccination_pfsi_conpars <- function(id,t,treat,type){
 
-  if(!is.numeric(t) | any(t < 0)){
+  if(!is.numeric(t) | t < 0){
     stop("time of pevaxx event must be a vector of positive floats")
   }
 
@@ -123,17 +123,12 @@ pevaxx_pfsi_conpars <- function(id,t,treat,type){
     stop("id must be a positive integer value")
   }
 
-  if(length(t) != length(treat)){
-    stop("length of 't' (time of vaxx event vector) must be same as 'treat' (treatment to accompany vaxx vector)")
-  }
-
   if(!(type %in% c("PE","GS"))){
     stop("vaccine 'type' must be PE (sporozoite-blocking) or GS (gametocyte-killing)")
   }
 
   list(
     id = as.integer(id),
-    n = length(t),
     tEvent = as.numeric(t),
     treat = as.logical(treat),
     type = as.character(type)

--- a/MASH-dev/SeanWu/MACRO-dev/MACRO/src/Tile.cpp
+++ b/MASH-dev/SeanWu/MACRO-dev/MACRO/src/Tile.cpp
@@ -27,6 +27,7 @@
 
 /*
   TO-DO:
+  * fix docs and take out 'n' in pevaxx_pfsi_conpars
   * heterogeneity in c; instead of setting infection = T/F, just move c
   * change how we store state in PfSI to just a single string (S,I,P)
   * investigate possibility to have a central logging mechanism that decides how to log events


### PR DESCRIPTION
change `pevaxx_pfsi_conpars` to `vaccination_pfsi_conpars` because both PE and GS vaccination events can be initialized in it.