### PR TITLE
Fix the condition for accepting movement Matrix in MACRO

### DIFF
--- a/MASH-dev/SeanWu/MACRO-dev/MACRO/R/Patch.R
+++ b/MASH-dev/SeanWu/MACRO-dev/MACRO/R/Patch.R
@@ -19,7 +19,7 @@
 
 #'
 #' @param id integer id
-#' @param move 'row' of the stochastic movement matri
+#' @param move 'row' of the stochastic human movement matrix
 #' @param bWeightZoo biting weight assigned to non-human hosts
 #' @param bWeightZootox biting weight assigned to endectocide-treated non-human hosts
 #' @param reservoir boolean; is this patch a reservoir? (no simulation of mosquitos)
@@ -32,7 +32,7 @@ patch_conpars <- function(id,move,bWeightZoo,bWeightZootox,reservoir,res_EIR){
     stop(paste0("id: ",id," not allowed; use non-negative integer id"))
   }
 
-  if(sum(move) != 1){
+  if(!all(rowSums(moveMat) == 1)){
     stop("movement vector 'move' must sum to one")
   }
 


### PR DESCRIPTION
## Proposed changes

Old condition for accepting movement matrix was sum(moveMat) == 1, which is > 1 for a multi-row movement matrix.  Now we check every row of the matrix and make sure that each row sums to 1.

## Types of changes

What types of changes does your code introduce to MASH?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] No changes (just sync or minor updates to non-essential code)