### PR TITLE
Changed condition for passing movement matrix to patch in MACRO

### DIFF
--- a/MASH-dev/SeanWu/MACRO-dev/MACRO/R/Patch.R
+++ b/MASH-dev/SeanWu/MACRO-dev/MACRO/R/Patch.R
@@ -26,13 +26,16 @@
 #' @param res_EIR fixed EIR for reservoir patch
 #'
 #' @export
+
+
 patch_conpars <- function(id,move,bWeightZoo,bWeightZootox,reservoir,res_EIR){
 
   if(!is.integer(id) | id < 0){
     stop(paste0("id: ",id," not allowed; use non-negative integer id"))
   }
 
-  if(!all(rowSums(moveMat) == 1)){
+
+  if(!all.equal(rowSums(move),rep(1,nrow(move)))){
     stop("movement vector 'move' must sum to one")
   }
 


### PR DESCRIPTION
## Proposed changes

In MASH-dev/SeanWu/MACRO-dev/MACRO/R/Patch.R
changed the condition for checking movement matrix to patch in MACRO to be more robust to machine tolerances:

  if(!all.equal(rowSums(move),rep(1,nrow(move)))){
    stop("movement vector 'move' must sum to one")
  }

## Types of changes

What types of changes does your code introduce to MASH?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] No changes (just sync or minor updates to non-essential code)